### PR TITLE
feat(admin): redesign Transportation list with modern card/table UI (……indigo)

### DIFF
--- a/Admin/MPTBM_Transportation.php
+++ b/Admin/MPTBM_Transportation.php
@@ -1,617 +1,441 @@
 <?php
-
+/**
+ * Transportation list - modern responsive card/table design.
+ * Mirrors the bus/rental fleet list design in the plugin's own indigo theme.
+ */
 class MPTBM_Transportation
 {
-    public function __construct(){
-
-        add_action( 'admin_menu', array( $this, 'mptbm_transportation_lists_menu' ) );
-
-        add_action( 'admin_menu', array( $this, 'reorder_mptbm_submenu' ), 999 );
-
-        add_action('admin_post_mptbm_trash_transport',  array( $this, 'mptbm_trash_transport_callback' ) );
+    public function __construct()
+    {
+        add_action('admin_menu', array($this, 'mptbm_transportation_lists_menu'));
+        add_action('admin_menu', array($this, 'reorder_mptbm_submenu'), 999);
+        add_action('admin_post_mptbm_trash_transport', array($this, 'mptbm_trash_transport_callback'));
+        add_action('admin_post_mptbm_restore_transport', array($this, 'mptbm_restore_transport_callback'));
+        add_action('admin_post_mptbm_delete_transport', array($this, 'mptbm_delete_transport_callback'));
     }
 
-    public function reorder_mptbm_submenu() {
-
+    public function reorder_mptbm_submenu()
+    {
         global $submenu;
-
         $parent = 'edit.php?post_type=mptbm_rent';
-
-        if ( isset( $submenu[$parent] ) ) {
+        if (isset($submenu[$parent])) {
             $new_order = array();
-            foreach ( $submenu[$parent] as $item ) {
-
-                if ( isset($item[2]) && $item[2] === 'mptbm_transportation_lists' ) {
-                    array_unshift( $new_order, $item );
+            foreach ($submenu[$parent] as $item) {
+                if (isset($item[2]) && $item[2] === 'mptbm_transportation_lists') {
+                    array_unshift($new_order, $item);
                 } else {
                     $new_order[] = $item;
                 }
             }
-
             $submenu[$parent] = $new_order;
         }
     }
 
-
-//esc_html_e('ON', 'ecab-taxi-booking-manager');
-    public function mptbm_transportation_lists_menu() {
-
+    public function mptbm_transportation_lists_menu()
+    {
         add_submenu_page(
             'edit.php?post_type=mptbm_rent',
             'Transportation Lists',
             'Transportation Lists',
             'manage_options',
             'mptbm_transportation_lists',
-            array( $this, 'mptbm_transportation_lists_page' )
+            array($this, 'mptbm_transportation_lists_page')
         );
-        }
+    }
 
-    function mptbm_trash_transport_callback() {
+    private function base_url()
+    {
+        return admin_url('edit.php?post_type=mptbm_rent&page=mptbm_transportation_lists');
+    }
 
-        if (!isset($_GET['id'])) {
+    /* ---- Action handlers (nonce protected, redirect back to page) ----- */
+    public function mptbm_trash_transport_callback()
+    {
+        $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+        if (!$id || !isset($_GET['_wpnonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['_wpnonce'])), 'mptbm_trash_' . $id)) {
             wp_die('Invalid request');
         }
-
-        $id = intval($_GET['id']);
-
-        // Optional: security check (recommended)
         if (!current_user_can('delete_post', $id)) {
             wp_die('You are not allowed to trash this item.');
         }
-
-        // WordPress built-in trash
         wp_trash_post($id);
-
-        wp_redirect(admin_url('edit.php?post_type=mptbm_rent&page=mptbm_transportation_lists'));
+        wp_safe_redirect($this->base_url());
         exit;
     }
 
-    public function mptbm_transportation_lists_page() {
-
-        $page = isset( $_GET['paged'] ) ? absint( $_GET['paged'] ) : 1;
-
-        $lists = $this->mptbm_get_rent_lists( $page, 6 );
-        $transportations = $lists['posts'];
-
-        $total_pages = $lists['pagination']['total_pages'];
-        $current     = $lists['pagination']['current_page'];
-        $total_posts = $lists['pagination']['total_posts'];
-        $per_page    = $lists['pagination']['per_page'];
-
-//        error_log( print_r( [ '$transportations' => $transportations ], true ) );
-
-        ?>
-
-        <div class="wrap mptbm_transportation_lists_wrapper">
-
-            <?php $this->mptbm_transportation_lists_header( $total_posts ); ?>
-
-            <?php $this->mptbm_transportation_lists_stats( $total_posts ); ?>
-
-            <?php $this->mptbm_transportation_lists_filter(); ?>
-
-            <div class="mptbm_transportation_lists_cards_wrapper">
-
-                <?php
-                if ( ! empty( $transportations ) ) {
-
-                    foreach ( $transportations as $transportation ) {
-
-                        $this->mptbm_transportation_lists_single_card( $transportation );
-                    }
-                }
-                ?>
-
-            </div>
-
-            <?php $this->mptbm_transportation_lists_footer( $lists, $total_pages, $current, $total_posts, $per_page ); ?>
-
-        </div>
-
-        <?php
+    public function mptbm_restore_transport_callback()
+    {
+        $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+        if (!$id || !isset($_GET['_wpnonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['_wpnonce'])), 'mptbm_restore_' . $id)) {
+            wp_die('Invalid request');
+        }
+        if (!current_user_can('edit_post', $id)) {
+            wp_die('You are not allowed to restore this item.');
+        }
+        wp_untrash_post($id);
+        wp_safe_redirect(add_query_arg('mptbm_status', 'trash', $this->base_url()));
+        exit;
     }
 
+    public function mptbm_delete_transport_callback()
+    {
+        $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+        if (!$id || !isset($_GET['_wpnonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['_wpnonce'])), 'mptbm_delete_' . $id)) {
+            wp_die('Invalid request');
+        }
+        if (!current_user_can('delete_post', $id)) {
+            wp_die('You are not allowed to delete this item.');
+        }
+        wp_delete_post($id, true);
+        wp_safe_redirect(add_query_arg('mptbm_status', 'trash', $this->base_url()));
+        exit;
+    }
 
-    /**
-     * Get Transport Rent List With Pagination
-     *
-     * @param int $paged
-     * @param int $per_page
-     *
-     * @return array
-     */
-    public function mptbm_get_rent_lists( $paged = 1, $per_page = 10 ) {
-
-        $args = array(
+    /* ---- Data --------------------------------------------------------- */
+    private function get_items($statuses = array('publish', 'draft', 'pending', 'private'))
+    {
+        $query = new WP_Query(array(
             'post_type'      => 'mptbm_rent',
-            'post_status'    => 'publish',
-            'posts_per_page' => $per_page,
-            'paged'          => $paged,
+            'post_status'    => $statuses,
+            'posts_per_page' => -1,
             'orderby'        => 'ID',
             'order'          => 'DESC',
-        );
-
-        $query = new WP_Query( $args );
-
-        $data = array();
-
-        if ( $query->have_posts() ) {
-
-            while ( $query->have_posts() ) {
-
-                $query->the_post();
-
-                $post_id = get_the_ID();
-
-                $item = get_post_meta( $post_id, 'mptbm_features', true );
-                $model = '';
-                if ( ! empty( $item ) && is_array( $item ) ){
-                    foreach ( $item as $feature ) {
-                        if ( isset( $feature['label'] ) && strtolower( $feature['label'] ) === 'model' ) {
-                            $model = $feature['text'];
-                            break;
-                        }
+            'no_found_rows'  => true,
+        ));
+        $items = array();
+        foreach ($query->posts as $post) {
+            $pid   = $post->ID;
+            $model = '';
+            $features = get_post_meta($pid, 'mptbm_features', true);
+            if (!empty($features) && is_array($features)) {
+                foreach ($features as $feature) {
+                    if (isset($feature['label']) && strtolower($feature['label']) === 'model') {
+                        $model = $feature['text'] ?? '';
+                        break;
                     }
                 }
-
-                $data[] = array(
-
-                    'id'       => $post_id,
-
-                    'title'    => get_the_title(),
-
-                    'location' => get_post_meta( $post_id, 'mptbm_location', true ),
-
-                    'type'     => get_post_meta( $post_id, 'mptbm_transport_type', true ),
-
-                    'km'       => get_post_meta( $post_id, 'mptbm_km_price', true ),
-
-                    'hourly'   => get_post_meta( $post_id, 'mptbm_hour_price', true ),
-
-                    'model'    => $model,
-
-                    'status'   => get_post_status( $post_id ),
-
-                    'image'    => get_post_meta( $post_id, 'feature_image', true ),
-
-                    'link_wc_product' => get_post_meta( $post_id, 'link_wc_product', true ),
-
-                    'price_based' => get_post_meta( $post_id, 'mptbm_price_based', true ),
-
-                );
             }
-
-            wp_reset_postdata();
+            $items[] = array(
+                'id'          => $pid,
+                'title'       => get_the_title($pid) ?: __('(no title)', 'ecab-taxi-booking-manager'),
+                'location'    => get_post_meta($pid, 'mptbm_location', true),
+                'type'        => get_post_meta($pid, 'mptbm_transport_type', true),
+                'km'          => get_post_meta($pid, 'mptbm_km_price', true),
+                'hourly'      => get_post_meta($pid, 'mptbm_hour_price', true),
+                'model'       => $model,
+                'status'      => $post->post_status,
+                'image'       => get_post_meta($pid, 'feature_image', true) ?: get_the_post_thumbnail_url($pid, 'medium_large'),
+                'price_based' => get_post_meta($pid, 'mptbm_price_based', true),
+                'author'      => get_the_author_meta('display_name', $post->post_author),
+                'edit_link'   => admin_url('admin.php?page=mptbm-rent-edit&post_id=' . $pid),
+                'trash_link'  => wp_nonce_url(admin_url('admin-post.php?action=mptbm_trash_transport&id=' . $pid), 'mptbm_trash_' . $pid),
+                'restore_link' => wp_nonce_url(admin_url('admin-post.php?action=mptbm_restore_transport&id=' . $pid), 'mptbm_restore_' . $pid),
+                'delete_link'  => wp_nonce_url(admin_url('admin-post.php?action=mptbm_delete_transport&id=' . $pid), 'mptbm_delete_' . $pid),
+            );
         }
 
-        return array(
-
-            'posts' => $data,
-
-            'pagination' => array(
-
-                'total_posts' => $query->found_posts,
-                'total_pages' => $query->max_num_pages,
-                'current_page' => $paged,
-                'per_page' => $per_page,
-
-            ),
-
-        );
+        return $items;
     }
 
-    /**
-     * Transportation Data
-     */
-
-    /**
-     * Header
-     */
-    private function mptbm_transportation_lists_header( $total_posts ) {
-        ?>
-
-        <div class="mptbm_transportation_lists_topbar">
-
-            <div>
-
-                <h1 class="mptbm_transportation_lists_page_title">
-                    <?php esc_html_e('Transportation', 'ecab-taxi-booking-manager');?>
-                </h1>
-
-                <div class="mptbm_transportation_lists_tabs">
-
-                    <a href="#" class="mptbm_transportation_lists_tab_active">
-                        <?php esc_html_e('All', 'ecab-taxi-booking-manager');?> (<?php echo esc_attr( $total_posts );?>)
-                    </a>
-
-                    <a href="#">
-                        <?php esc_html_e('Published', 'ecab-taxi-booking-manager');?> (<?php echo esc_attr( $total_posts );?>)
-                    </a>
-
-                    <a href="#">
-                        <?php esc_html_e('Trashed', 'ecab-taxi-booking-manager');?> (<?php echo esc_attr( $total_posts );?>)
-                    </a>
-
-                </div>
-
-            </div>
-
-            <a href="<?php echo esc_url( admin_url( 'admin.php?page=mptbm-rent-edit' ) ); ?>"
-               class="mptbm_transportation_lists_add_btn">
-                <span class="dashicons dashicons-plus-alt2"></span>
-                <?php esc_html_e( 'Add New Transportation', 'ecab-taxi-booking-manager' ); ?>
-            </a>
-
-        </div>
-
-        <?php
-    }
-
-    private static function mptbm_get_current_month_sales_total() {
-
-        $start_date = date('Y-m-01 00:00:00');
-        $end_date   = date('Y-m-t 23:59:59');
-
-        $args = array(
+    private static function mptbm_get_current_month_sales_total()
+    {
+        $start_date = gmdate('Y-m-01 00:00:00');
+        $end_date   = gmdate('Y-m-t 23:59:59');
+        $query = new WP_Query(array(
             'post_type'      => 'mptbm_booking',
             'post_status'    => 'publish',
             'posts_per_page' => -1,
+            'fields'         => 'ids',
             'meta_query'     => array(
                 array(
                     'key'     => 'mptbm_date',
                     'value'   => array($start_date, $end_date),
                     'compare' => 'BETWEEN',
-                    'type'    => 'DATETIME'
-                )
-            )
-        );
-
-        $query = new WP_Query($args);
-
+                    'type'    => 'DATETIME',
+                ),
+            ),
+        ));
         $total = 0;
-
-        while ( $query->have_posts() ) {
-            $query->the_post();
-
-            $price = get_post_meta(get_the_ID(), 'mptbm_tp', true);
-            $total += floatval($price);
+        foreach ($query->posts as $bid) {
+            $total += floatval(get_post_meta($bid, 'mptbm_tp', true));
         }
 
-        wp_reset_postdata();
-
-        return number_format($total, 2, '.', '');
+        return $total;
     }
 
-    /**
-     * Stats
-     */
-    private function mptbm_transportation_lists_stats( $total_posts ) {
+    private function initials($name)
+    {
+        $name = trim(wp_strip_all_tags((string) $name));
+        if ($name === '') {
+            return '?';
+        }
+        $parts = preg_split('/\s+/', $name);
+        $first = mb_substr($parts[0], 0, 1);
+        $last  = count($parts) > 1 ? mb_substr(end($parts), 0, 1) : '';
 
-        $total_revenue = self::mptbm_get_current_month_sales_total();
-        ?>
-
-        <div class="mptbm_transportation_lists_stats_wrapper">
-
-            <div class="mptbm_transportation_lists_stats_card">
-
-                <div class="mptbm_transportation_lists_stats_icon">
-                    <span class="dashicons dashicons-car"></span>
-                </div>
-
-                <div>
-                    <div class="mptbm_transportation_lists_stats_label">
-                        <?php esc_html_e('ACTIVE FLEET', 'ecab-taxi-booking-manager');?>
-                    </div>
-
-                    <div class="mptbm_transportation_lists_stats_value">
-                        <?php echo esc_attr( $total_posts );?>  <?php esc_html_e('Vehicles', 'ecab-taxi-booking-manager');?>
-                    </div>
-                </div>
-
-            </div>
-
-            <div class="mptbm_transportation_lists_stats_card">
-
-                <div class="mptbm_transportation_lists_stats_icon">
-                    <span class="dashicons dashicons-location"></span>
-                </div>
-
-                <div>
-                    <div class="mptbm_transportation_lists_stats_label">
-                        <?php esc_html_e('TOTAL ROUTES', 'ecab-taxi-booking-manager');?>
-                    </div>
-
-                    <div class="mptbm_transportation_lists_stats_value">
-                        <?php esc_html_e('24 Daily', 'ecab-taxi-booking-manager');?>
-                    </div>
-                </div>
-
-            </div>
-
-            <div class="mptbm_transportation_lists_stats_card">
-
-                <div class="mptbm_transportation_lists_stats_icon">
-                    <span class="dashicons dashicons-money-alt"></span>
-                </div>
-
-                <div>
-                    <div class="mptbm_transportation_lists_stats_label">
-                        <?php esc_html_e('AVG. REVENUE', 'ecab-taxi-booking-manager');?>
-                    </div>
-
-                    <div class="mptbm_transportation_lists_stats_value">
-                        <?php echo esc_attr( $total_revenue ); ' '.esc_html_e('/mo', 'ecab-taxi-booking-manager');?>
-                    </div>
-                </div>
-
-            </div>
-
-        </div>
-
-        <?php
+        return mb_strtoupper($first . $last);
     }
 
-    /**
-     * Filter Bar
-     */
-    private function mptbm_transportation_lists_filter() {
-        ?>
-
-        <div class="mptbm_transportation_lists_filter_bar">
-
-            <div class="mptbm_transportation_lists_filter_left">
-
-                <select class="mptbm_transportation_lists_bulk_select">
-                    <option> <?php esc_html_e('Bulk actions', 'ecab-taxi-booking-manager');?></option>
-                </select>
-
-                <button class="mptbm_transportation_lists_apply_btn">
-                    <?php esc_html_e('Apply', 'ecab-taxi-booking-manager');?>
-                </button>
-
-            </div>
-
-            <div class="mptbm_transportation_lists_search_box">
-
-                <span class="dashicons dashicons-search"></span>
-
-                <input name="mptbm_search_by_title" id="mptbm_search_by_title" type="text" placeholder="Search Transportation...">
-
-                <button><?php esc_html_e('Search', 'ecab-taxi-booking-manager');?></button>
-
-            </div>
-
-        </div>
-
-        <?php
+    private function status_label($status)
+    {
+        switch ($status) {
+            case 'publish':
+                return __('Published', 'ecab-taxi-booking-manager');
+            case 'draft':
+                return __('Draft', 'ecab-taxi-booking-manager');
+            case 'pending':
+                return __('Pending', 'ecab-taxi-booking-manager');
+            case 'private':
+                return __('Private', 'ecab-taxi-booking-manager');
+            default:
+                return ucfirst($status);
+        }
     }
 
-    /**
-     * Single Card
-     */
-    private function mptbm_transportation_lists_single_card( $item ) {
+    private function money($amount)
+    {
+        if ($amount === '' || $amount === null) {
+            return '';
+        }
+        if (function_exists('wc_price') && is_numeric($amount)) {
+            return wp_strip_all_tags(wc_price($amount));
+        }
 
+        return esc_html($amount);
+    }
+
+    /* ---- Page --------------------------------------------------------- */
+    public function mptbm_transportation_lists_page()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $is_trash = isset($_GET['mptbm_status']) && sanitize_text_field(wp_unslash($_GET['mptbm_status'])) === 'trash';
+
+        $active    = $this->get_items();
+        $total     = count($active);
+        $published = 0;
+        $draft     = 0;
+        $types     = array();
+        foreach ($active as $it) {
+            if ($it['status'] === 'publish') {
+                $published++;
+            } elseif ($it['status'] === 'draft') {
+                $draft++;
+            }
+            if ($it['type']) {
+                $types[$it['type']] = true;
+            }
+        }
+        $revenue = self::mptbm_get_current_month_sales_total();
+
+        $status_counts = wp_count_posts('mptbm_rent');
+        $trash         = isset($status_counts->trash) ? (int) $status_counts->trash : 0;
+
+        $items     = $is_trash ? $this->get_items(array('trash')) : $active;
+        $base_url  = $this->base_url();
+        $trash_url = add_query_arg('mptbm_status', 'trash', $base_url);
+        $add_url   = admin_url('admin.php?page=mptbm-rent-edit');
         ?>
+        <div class="wrap mptbm-fleet-wrap">
+            <div class="mptbm-fleet">
 
-        <div class="mptbm_transportation_lists_card" data-transport-title="<?php echo esc_attr( $item['title'] );?>">
-
-            <div class="mptbm_transportation_lists_image_area">
-
-                <div class="mptbm_transportation_lists_badge">
-                    <span class="dashicons dashicons-category"></span>
-                    <?php echo esc_html( $item['price_based'] ); ?>
-                </div>
-
-                <img src="<?php echo esc_url( $item['image'] ); ?>" alt="">
-
-            </div>
-
-            <div class="mptbm_transportation_lists_content">
-
-                <div class="mptbm_transportation_lists_card_top">
-
-                    <div>
-
-                        <h2 class="mptbm_transportation_lists_vehicle_title">
-                            <span class="dashicons dashicons-car"></span>
-                            <?php echo esc_html( $item['title'] ); ?>
-                        </h2>
-
-                        <div class="mptbm_transportation_lists_location">
-
-                            <span class="dashicons dashicons-location"></span>
-
-                            <?php echo esc_html( $item['location'] ); ?>
-
-                        </div>
-
+                <div class="mptbm-page-header">
+                    <div class="mptbm-page-title"><?php esc_html_e('Transportation', 'ecab-taxi-booking-manager'); ?>
+                        <span><?php echo esc_html(sprintf(_n('%d vehicle', '%d vehicles', $total, 'ecab-taxi-booking-manager'), $total)); ?></span>
                     </div>
-
-                    <div class="mptbm_transportation_lists_action_buttons">
-
-                        <a href="<?php echo esc_url( admin_url('admin.php?page=mptbm-rent-edit&post_id=' . $item['id']) ); ?>"
-                           class="mptbm_transportation_lists_edit_btn">
-                            <span class="dashicons dashicons-edit"></span>
+                    <div class="mptbm-header-actions">
+                        <a class="mptbm-add-btn" href="<?php echo esc_url($add_url); ?>">
+                            <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                            <?php esc_html_e('Add New Transportation', 'ecab-taxi-booking-manager'); ?>
                         </a>
-
-                        <a href="<?php echo esc_url( admin_url('admin-post.php?action=mptbm_trash_transport&id=' . $item['id']) ); ?>"
-                           class="mptbm_transportation_lists_delete_btn mptbm-trash-confirm">
-                            <span class="dashicons dashicons-trash"></span>
-                        </a>
-
                     </div>
-
                 </div>
 
-                <div class="mptbm_transportation_lists_meta_box">
-
-                    <div class="mptbm_transportation_lists_meta_item">
-
-                        <div class="mptbm_transportation_lists_meta_label">
-                            <span class="dashicons dashicons-money-alt"></span>
-                            <?php esc_html_e('KM PRICE', 'ecab-taxi-booking-manager');?>
+                <div class="mptbm-stats">
+                    <div class="mptbm-stat-card">
+                        <div class="mptbm-stat-icon indigo">
+                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M5 17h14M6 17l1.5-5h9L18 17M7.5 12l1-4h7l1 4"/><circle cx="7.5" cy="17.5" r="1.5"/><circle cx="16.5" cy="17.5" r="1.5"/></svg>
                         </div>
-
-                        <div class="mptbm_transportation_lists_meta_value">
-                            <?php echo esc_html( $item['km'] ); ?>
-                        </div>
-
+                        <div><div class="mptbm-stat-num"><?php echo esc_html($total); ?></div><div class="mptbm-stat-label"><?php esc_html_e('Active Fleet', 'ecab-taxi-booking-manager'); ?></div></div>
                     </div>
-
-                    <div class="mptbm_transportation_lists_meta_item">
-
-                        <div class="mptbm_transportation_lists_meta_label">
-                            <span class="dashicons dashicons-clock"></span>
-                            <?php esc_html_e('HOURLY PRICE', 'ecab-taxi-booking-manager');?>
+                    <div class="mptbm-stat-card">
+                        <div class="mptbm-stat-icon green">
+                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"/></svg>
                         </div>
-
-                        <div class="mptbm_transportation_lists_meta_value">
-                            <?php echo esc_html( $item['hourly'] ); ?>
-                        </div>
-
+                        <div><div class="mptbm-stat-num"><?php echo esc_html($published); ?></div><div class="mptbm-stat-label"><?php esc_html_e('Published', 'ecab-taxi-booking-manager'); ?></div></div>
                     </div>
-
-                    <div class="mptbm_transportation_lists_meta_item">
-
-                        <div class="mptbm_transportation_lists_meta_label">
-                            <span class="dashicons dashicons-admin-tools"></span>
-                            <?php esc_html_e('MODEL', 'ecab-taxi-booking-manager');?>
+                    <div class="mptbm-stat-card">
+                        <div class="mptbm-stat-icon orange">
+                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
                         </div>
-
-                        <div class="mptbm_transportation_lists_meta_value_black">
-                            <?php echo esc_html( $item['model'] ); ?>
-                        </div>
-
+                        <div><div class="mptbm-stat-num"><?php echo esc_html($draft); ?></div><div class="mptbm-stat-label"><?php esc_html_e('Draft', 'ecab-taxi-booking-manager'); ?></div></div>
                     </div>
-
-                    <div class="mptbm_transportation_lists_meta_item">
-
-                        <div class="mptbm_transportation_lists_meta_label">
-                            <span class="dashicons dashicons-yes-alt"></span>
-                            <?php esc_html_e('STATUS', 'ecab-taxi-booking-manager');?>
+                    <div class="mptbm-stat-card">
+                        <div class="mptbm-stat-icon blue">
+                            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>
                         </div>
-
-                        <div class="mptbm_transportation_lists_meta_status">
-
-                            <span></span>
-
-                            <?php echo esc_html( $item['status'] ); ?>
-
-                        </div>
-
+                        <div><div class="mptbm-stat-num"><?php echo esc_html($this->money($revenue) ?: '0'); ?></div><div class="mptbm-stat-label"><?php esc_html_e('Revenue / mo', 'ecab-taxi-booking-manager'); ?></div></div>
                     </div>
-
                 </div>
 
-            </div>
-
-        </div>
-
-        <?php
-    }
-
-    /**
-     * Footer
-     */
-    private function mptbm_transportation_lists_footer( $lists, $total_pages, $current, $total_posts, $per_page ) {
-
-        // Current showing items
-        $start_item = ( ( $current - 1 ) * $per_page ) + 1;
-        $end_item   = min( $current * $per_page, $total_posts );
-
-        ?>
-
-        <div class="mptbm_transportation_lists_footer">
-
-            <div class="mptbm_transportation_lists_footer_text">
-
-                <?php esc_html_e('Showing', 'ecab-taxi-booking-manager');?>
-                <?php echo esc_html( $start_item ); ?>
-                -
-                <?php echo esc_html( $end_item ); ?>
-
-                <?php esc_html_e('of', 'ecab-taxi-booking-manager');?>
-
-                <?php echo esc_html( $total_posts ); ?>
-
-                <?php esc_html_e('Transportation Items', 'ecab-taxi-booking-manager');?>
-
-            </div>
-
-            <?php if ( $total_pages > 1 ) : ?>
-
-                <div class="mptbm_transportation_lists_pagination">
-
-                    <!-- Previous Button -->
-                    <?php if ( $current > 1 ) : ?>
-
-                        <?php
-                        $prev_url = admin_url(
-                            'edit.php?post_type=mptbm_rent&page=mptbm_transportation_lists&paged=' . ( $current - 1 )
-                        );
-                        ?>
-
-                        <a href="<?php echo esc_url( $prev_url ); ?>" class="mptbm_pagination_btn">
-
-                            <span class="dashicons dashicons-arrow-left-alt2"></span>
-
-                        </a>
-
-                    <?php endif; ?>
-
-
-
-                    <div class="mptbm_transportation_lists_pagination_text">
-
-                        <?php
-
-                        for ( $i = 1; $i <= $total_pages; $i++ ) {
-
-                            $active = ( $current == $i ) ? 'active' : '';
-
-                            $url = admin_url(
-                                'edit.php?post_type=mptbm_rent&page=mptbm_transportation_lists&paged=' . $i
-                            );
-
-                            ?>
-
-                            <a
-                                class="mptbm_pagination_number <?php echo esc_attr( $active ); ?>"
-                                href="<?php echo esc_url( $url ); ?>"
-                            >
-                                <?php echo esc_html( $i ); ?>
+                <div class="mptbm-filters">
+                    <div class="mptbm-tab-pills">
+                        <?php if ($is_trash) : ?>
+                            <a class="mptbm-tab-pill" href="<?php echo esc_url($base_url); ?>"><?php printf(esc_html__('All (%d)', 'ecab-taxi-booking-manager'), $total); ?></a>
+                            <a class="mptbm-tab-pill" href="<?php echo esc_url($base_url); ?>"><?php printf(esc_html__('Published (%d)', 'ecab-taxi-booking-manager'), $published); ?></a>
+                            <a class="mptbm-tab-pill" href="<?php echo esc_url($base_url); ?>"><?php printf(esc_html__('Draft (%d)', 'ecab-taxi-booking-manager'), $draft); ?></a>
+                            <span class="mptbm-tab-pill mptbm-tab-trash active">
+                                <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                                <?php printf(esc_html__('Trash (%d)', 'ecab-taxi-booking-manager'), $trash); ?>
+                            </span>
+                        <?php else : ?>
+                            <button class="mptbm-tab-pill mptbm-filter-pill active" data-status=""><?php printf(esc_html__('All (%d)', 'ecab-taxi-booking-manager'), $total); ?></button>
+                            <button class="mptbm-tab-pill mptbm-filter-pill" data-status="publish"><?php printf(esc_html__('Published (%d)', 'ecab-taxi-booking-manager'), $published); ?></button>
+                            <button class="mptbm-tab-pill mptbm-filter-pill" data-status="draft"><?php printf(esc_html__('Draft (%d)', 'ecab-taxi-booking-manager'), $draft); ?></button>
+                            <a class="mptbm-tab-pill mptbm-tab-trash" href="<?php echo esc_url($trash_url); ?>" title="<?php esc_attr_e('View trashed items', 'ecab-taxi-booking-manager'); ?>">
+                                <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                                <?php printf(esc_html__('Trash (%d)', 'ecab-taxi-booking-manager'), $trash); ?>
                             </a>
-
-                            <?php
-                        }
-                        ?>
-
+                        <?php endif; ?>
                     </div>
-
-                    <!-- Next Button -->
-                    <?php if ( $current < $total_pages ) : ?>
-
-                        <?php
-                        $next_url = admin_url(
-                            'edit.php?post_type=mptbm_rent&page=mptbm_transportation_lists&paged=' . ( $current + 1 )
-                        );
-                        ?>
-
-                        <a href="<?php echo esc_url( $next_url ); ?>" class="mptbm_pagination_btn">
-                            <span class="dashicons dashicons-arrow-right-alt2"></span>
-                        </a>
-
+                    <div class="mptbm-search-box">
+                        <svg class="mptbm-search-icon" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                        <input type="text" placeholder="<?php esc_attr_e('Search transportation...', 'ecab-taxi-booking-manager'); ?>" id="mptbmSearchInput" autocomplete="off">
+                        <button type="button" class="mptbm-search-clear" id="mptbmSearchClear" aria-label="<?php esc_attr_e('Clear search', 'ecab-taxi-booking-manager'); ?>">
+                            <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                        </button>
+                    </div>
+                    <?php if (!empty($types)) : ?>
+                        <select class="mptbm-filter-select" id="mptbmTypeFilter">
+                            <option value=""><?php esc_html_e('All Types', 'ecab-taxi-booking-manager'); ?></option>
+                            <?php foreach (array_keys($types) as $t) : ?>
+                                <option value="<?php echo esc_attr($t); ?>"><?php echo esc_html(ucfirst($t)); ?></option>
+                            <?php endforeach; ?>
+                        </select>
                     <?php endif; ?>
-
+                    <div class="mptbm-view-toggle">
+                        <button class="mptbm-vtog active" id="mptbmGridBtn" title="<?php esc_attr_e('Grid view', 'ecab-taxi-booking-manager'); ?>">
+                            <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                        </button>
+                        <button class="mptbm-vtog" id="mptbmListBtn" title="<?php esc_attr_e('List view', 'ecab-taxi-booking-manager'); ?>">
+                            <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+                        </button>
+                    </div>
                 </div>
 
-            <?php endif; ?>
+                <?php if (empty($items)) : ?>
+                    <div class="mptbm-no-data">
+                        <?php if ($is_trash) : ?>
+                            <p><?php esc_html_e('Trash is empty.', 'ecab-taxi-booking-manager'); ?></p>
+                            <a class="mptbm-classic-link" href="<?php echo esc_url($base_url); ?>"><?php esc_html_e('Back to list', 'ecab-taxi-booking-manager'); ?></a>
+                        <?php else : ?>
+                            <p><?php esc_html_e('No transportation found yet.', 'ecab-taxi-booking-manager'); ?></p>
+                            <a class="mptbm-add-btn" href="<?php echo esc_url($add_url); ?>"><?php esc_html_e('Add your first transportation', 'ecab-taxi-booking-manager'); ?></a>
+                        <?php endif; ?>
+                    </div>
+                <?php else : ?>
 
+                <div class="mptbm-grid" id="mptbmGrid">
+                    <?php foreach ($items as $it) : ?>
+                        <div class="mptbm-card" data-name="<?php echo esc_attr(strtolower($it['title'] . ' ' . $it['location'] . ' ' . $it['model'])); ?>" data-type="<?php echo esc_attr($it['type']); ?>" data-status="<?php echo esc_attr($it['status']); ?>">
+                            <div class="mptbm-thumb">
+                                <?php if ($it['image']) : ?>
+                                    <img src="<?php echo esc_url($it['image']); ?>" alt="<?php echo esc_attr($it['title']); ?>">
+                                <?php else : ?>
+                                    <div class="mptbm-thumb-placeholder">
+                                        <svg width="48" height="48" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M5 17h14M6 17l1.5-5h9L18 17M7.5 12l1-4h7l1 4"/><circle cx="7.5" cy="17.5" r="1.5"/><circle cx="16.5" cy="17.5" r="1.5"/></svg>
+                                    </div>
+                                <?php endif; ?>
+                                <div class="mptbm-thumb-overlay"></div>
+                                <div class="mptbm-thumb-badges">
+                                    <?php if ($it['price_based']) : ?><span class="mptbm-thumb-badge type"><?php echo esc_html($it['price_based']); ?></span><?php endif; ?>
+                                    <?php if ($it['type']) : ?><span class="mptbm-thumb-badge alt"><?php echo esc_html(ucfirst($it['type'])); ?></span><?php endif; ?>
+                                </div>
+                                <div class="mptbm-actions-top">
+                                    <?php if ($is_trash) : ?>
+                                        <a class="mptbm-act-btn restore" href="<?php echo esc_url($it['restore_link']); ?>" title="<?php esc_attr_e('Restore', 'ecab-taxi-booking-manager'); ?>">
+                                            <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 12a9 9 0 109-9 9 9 0 00-7 3.3"/><polyline points="3 4 3 8 7 8"/></svg>
+                                        </a>
+                                        <a class="mptbm-act-btn del" href="<?php echo esc_url($it['delete_link']); ?>" title="<?php esc_attr_e('Delete Permanently', 'ecab-taxi-booking-manager'); ?>" onclick="return confirm('<?php echo esc_js(__('Permanently delete this item? This cannot be undone.', 'ecab-taxi-booking-manager')); ?>');">
+                                            <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                                        </a>
+                                    <?php else : ?>
+                                        <a class="mptbm-act-btn edit" href="<?php echo esc_url($it['edit_link']); ?>" title="<?php esc_attr_e('Edit', 'ecab-taxi-booking-manager'); ?>">
+                                            <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                                        </a>
+                                        <a class="mptbm-act-btn del" href="<?php echo esc_url($it['trash_link']); ?>" title="<?php esc_attr_e('Move to Trash', 'ecab-taxi-booking-manager'); ?>" onclick="return confirm('<?php echo esc_js(__('Move this item to Trash?', 'ecab-taxi-booking-manager')); ?>');">
+                                            <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+                                        </a>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                            <div class="mptbm-body">
+                                <?php if ($is_trash) : ?>
+                                    <span class="mptbm-name"><?php echo esc_html($it['title']); ?></span>
+                                <?php else : ?>
+                                    <a class="mptbm-name" href="<?php echo esc_url($it['edit_link']); ?>"><?php echo esc_html($it['title']); ?></a>
+                                <?php endif; ?>
+                                <?php if ($it['location']) : ?>
+                                    <div class="mptbm-location"><svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"/><circle cx="12" cy="10" r="3"/></svg> <?php echo esc_html($it['location']); ?></div>
+                                <?php endif; ?>
+                                <div class="mptbm-meta-grid">
+                                    <div class="mptbm-meta-cell"><span class="mptbm-meta-k"><?php esc_html_e('KM Price', 'ecab-taxi-booking-manager'); ?></span><span class="mptbm-meta-v"><?php echo esc_html($this->money($it['km']) ?: '-'); ?></span></div>
+                                    <div class="mptbm-meta-cell"><span class="mptbm-meta-k"><?php esc_html_e('Hourly', 'ecab-taxi-booking-manager'); ?></span><span class="mptbm-meta-v"><?php echo esc_html($this->money($it['hourly']) ?: '-'); ?></span></div>
+                                    <div class="mptbm-meta-cell"><span class="mptbm-meta-k"><?php esc_html_e('Model', 'ecab-taxi-booking-manager'); ?></span><span class="mptbm-meta-v"><?php echo esc_html($it['model'] ?: '-'); ?></span></div>
+                                </div>
+                                <div class="mptbm-footer">
+                                    <div class="mptbm-author"><span class="mptbm-author-avatar"><?php echo esc_html($this->initials($it['author'])); ?></span> <?php echo esc_html($it['author']); ?></div>
+                                    <span class="mptbm-status-dot status-<?php echo esc_attr($it['status']); ?>"><?php echo esc_html($this->status_label($it['status'])); ?></span>
+                                </div>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+
+                <table class="mptbm-table" id="mptbmTable">
+                    <thead>
+                        <tr>
+                            <th><?php esc_html_e('Transportation', 'ecab-taxi-booking-manager'); ?></th>
+                            <th><?php esc_html_e('Location', 'ecab-taxi-booking-manager'); ?></th>
+                            <th><?php esc_html_e('KM Price', 'ecab-taxi-booking-manager'); ?></th>
+                            <th><?php esc_html_e('Hourly', 'ecab-taxi-booking-manager'); ?></th>
+                            <th><?php esc_html_e('Status', 'ecab-taxi-booking-manager'); ?></th>
+                            <th><?php esc_html_e('Actions', 'ecab-taxi-booking-manager'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($items as $it) : ?>
+                            <tr class="mptbm-row" data-name="<?php echo esc_attr(strtolower($it['title'] . ' ' . $it['location'] . ' ' . $it['model'])); ?>" data-type="<?php echo esc_attr($it['type']); ?>" data-status="<?php echo esc_attr($it['status']); ?>">
+                                <td data-label="<?php esc_attr_e('Name', 'ecab-taxi-booking-manager'); ?>"><?php if ($is_trash) : ?><?php echo esc_html($it['title']); ?><?php else : ?><a href="<?php echo esc_url($it['edit_link']); ?>"><?php echo esc_html($it['title']); ?></a><?php endif; ?></td>
+                                <td data-label="<?php esc_attr_e('Location', 'ecab-taxi-booking-manager'); ?>"><?php echo esc_html($it['location'] ?: '-'); ?></td>
+                                <td data-label="<?php esc_attr_e('KM Price', 'ecab-taxi-booking-manager'); ?>"><?php echo esc_html($this->money($it['km']) ?: '-'); ?></td>
+                                <td data-label="<?php esc_attr_e('Hourly', 'ecab-taxi-booking-manager'); ?>"><?php echo esc_html($this->money($it['hourly']) ?: '-'); ?></td>
+                                <td data-label="<?php esc_attr_e('Status', 'ecab-taxi-booking-manager'); ?>"><span class="mptbm-status-dot status-<?php echo esc_attr($it['status']); ?>"><?php echo esc_html($this->status_label($it['status'])); ?></span></td>
+                                <td data-label="<?php esc_attr_e('Actions', 'ecab-taxi-booking-manager'); ?>">
+                                    <?php if ($is_trash) : ?>
+                                        <a class="mptbm-table-edit" href="<?php echo esc_url($it['restore_link']); ?>"><?php esc_html_e('Restore', 'ecab-taxi-booking-manager'); ?></a>
+                                        <a class="mptbm-table-del" href="<?php echo esc_url($it['delete_link']); ?>" onclick="return confirm('<?php echo esc_js(__('Permanently delete this item? This cannot be undone.', 'ecab-taxi-booking-manager')); ?>');"><?php esc_html_e('Delete', 'ecab-taxi-booking-manager'); ?></a>
+                                    <?php else : ?>
+                                        <a class="mptbm-table-edit" href="<?php echo esc_url($it['edit_link']); ?>"><?php esc_html_e('Edit', 'ecab-taxi-booking-manager'); ?></a>
+                                        <a class="mptbm-table-del" href="<?php echo esc_url($it['trash_link']); ?>" onclick="return confirm('<?php echo esc_js(__('Move this item to Trash?', 'ecab-taxi-booking-manager')); ?>');"><?php esc_html_e('Trash', 'ecab-taxi-booking-manager'); ?></a>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+
+                <div class="mptbm-empty" id="mptbmEmptyMsg"><?php esc_html_e('No transportation found matching your search.', 'ecab-taxi-booking-manager'); ?></div>
+
+                <div class="mptbm-pagination" id="mptbmPagination">
+                    <div class="mptbm-page-info" id="mptbmPageInfo"></div>
+                    <div class="mptbm-page-btns" id="mptbmPageBtns"></div>
+                </div>
+
+                <?php endif; ?>
+            </div>
         </div>
-
         <?php
     }
-
-
 }
+
 new MPTBM_Transportation();

--- a/assets/admin/mptbm_transportation_lists.css
+++ b/assets/admin/mptbm_transportation_lists.css
@@ -1,557 +1,171 @@
-/* ===================================================
-   MPTBM TRANSPORTATION LISTS
-=================================================== */
+/* ==========================================================================
+   MPTBM Transportation - modern responsive list design (indigo theme)
+   Scoped under .mptbm-fleet so it never leaks into the rest of wp-admin.
+   ========================================================================== */
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap');
 
-.mptbm_transportation_lists_wrapper{
-    max-width:1200px;
-    margin:0 auto;
-    padding:18px 20px 30px 18px;
-    background:#f6f8fc;
-    font-family:Inter,sans-serif;
+.mptbm-fleet-wrap{margin:0;}
+.mptbm-fleet *,.mptbm-fleet *::before,.mptbm-fleet *::after{box-sizing:border-box;}
+.mptbm-fleet{
+  --mp-bg:#f1f5f9;--mp-white:#fff;--mp-ink:#1e293b;--mp-ink2:#334155;
+  --mp-muted:#64748b;--mp-border:#e2e8f0;--mp-indigo:#4f46e5;--mp-indigo-dark:#2f1fd1;
+  --mp-indigo-soft:#eef2ff;--mp-green:#16a34a;--mp-green-soft:#dcfce7;
+  --mp-blue:#2563eb;--mp-blue-soft:#dbeafe;--mp-orange:#ea580c;--mp-orange-soft:#ffedd5;
+  --mp-shadow:0 2px 16px rgba(30,41,59,.08);--mp-shadow-hover:0 8px 32px rgba(30,41,59,.14);
+  font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  background:var(--mp-bg);color:var(--mp-ink);
+  margin:10px 20px 40px 0;padding:28px;border-radius:18px;
 }
+.mptbm-fleet a{box-shadow:none;}
+.mptbm-fleet a:focus{box-shadow:none;outline:none;}
 
-/* ===================================================
-   TOPBAR
-=================================================== */
+/* HEADER */
+.mptbm-page-header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:24px;flex-wrap:wrap;}
+.mptbm-page-title{font-size:25px;font-weight:800;color:var(--mp-ink);letter-spacing:-.02em;}
+.mptbm-page-title span{color:var(--mp-muted);font-weight:400;font-size:15px;margin-left:8px;}
+.mptbm-header-actions{display:flex;align-items:center;gap:10px;}
+.mptbm-classic-link{display:inline-flex;align-items:center;gap:7px;font-size:13px;font-weight:700;color:var(--mp-ink2) !important;text-decoration:none;background:var(--mp-white);border:1px solid var(--mp-border);padding:9px 16px;border-radius:10px;transition:all .2s;}
+.mptbm-classic-link:hover{color:var(--mp-indigo) !important;border-color:var(--mp-indigo);box-shadow:var(--mp-shadow);transform:translateY(-1px);}
+.mptbm-add-btn{display:inline-flex;align-items:center;gap:8px;background:var(--mp-indigo);color:#fff !important;font-size:13px;font-weight:700;padding:10px 20px;border-radius:10px;border:none;cursor:pointer;text-decoration:none;transition:background .2s,transform .15s;}
+.mptbm-add-btn:hover{background:var(--mp-indigo-dark);color:#fff !important;transform:translateY(-1px);}
 
-.mptbm_transportation_lists_topbar{
-    display:flex;
-    align-items:flex-start;
-    justify-content:space-between;
-    margin-bottom:18px;
+/* STATS */
+.mptbm-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:24px;}
+.mptbm-stat-card{background:var(--mp-white);border-radius:14px;padding:18px 20px;border:1px solid var(--mp-border);display:flex;align-items:center;gap:14px;transition:box-shadow .2s;}
+.mptbm-stat-card:hover{box-shadow:var(--mp-shadow);}
+.mptbm-stat-icon{width:44px;height:44px;border-radius:12px;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+.mptbm-stat-icon.indigo{background:var(--mp-indigo-soft);color:var(--mp-indigo);}
+.mptbm-stat-icon.green{background:var(--mp-green-soft);color:var(--mp-green);}
+.mptbm-stat-icon.blue{background:var(--mp-blue-soft);color:var(--mp-blue);}
+.mptbm-stat-icon.orange{background:var(--mp-orange-soft);color:var(--mp-orange);}
+.mptbm-stat-num{font-size:22px;font-weight:800;color:var(--mp-ink);line-height:1;}
+.mptbm-stat-label{font-size:11px;color:var(--mp-muted);margin-top:3px;font-weight:500;}
+
+/* FILTERS */
+.mptbm-filters{display:flex;align-items:center;gap:12px;margin-bottom:20px;flex-wrap:wrap;}
+.mptbm-tab-pills{display:flex;gap:6px;background:var(--mp-white);padding:5px;border-radius:10px;border:1px solid var(--mp-border);}
+.mptbm-tab-pill{display:inline-flex;align-items:center;gap:5px;padding:6px 14px;border-radius:7px;font-size:12px;font-weight:600;cursor:pointer;color:var(--mp-muted);transition:all .2s;border:none;background:none;font-family:inherit;text-decoration:none;line-height:1.5;}
+.mptbm-tab-pill.active{background:var(--mp-indigo);color:#fff;}
+.mptbm-tab-trash{color:var(--mp-muted) !important;}
+.mptbm-tab-trash svg{opacity:.8;}
+.mptbm-tab-trash:not(.active):hover{background:var(--mp-indigo-soft);color:var(--mp-indigo) !important;}
+.mptbm-tab-trash.active{background:var(--mp-indigo);color:#fff !important;}
+.mptbm-tab-trash.active svg{opacity:1;}
+.mptbm-search-box{display:flex;align-items:center;gap:8px;background:var(--mp-white);border:1px solid var(--mp-border);border-radius:10px;padding:6px 14px;flex:1;max-width:300px;min-width:180px;color:var(--mp-muted);transition:border-color .2s,box-shadow .2s;}
+.mptbm-search-box.is-focused{border-color:var(--mp-indigo);box-shadow:0 0 0 3px var(--mp-indigo-soft);}
+.mptbm-search-box .mptbm-search-icon{flex-shrink:0;transition:color .2s;}
+.mptbm-search-box.is-focused .mptbm-search-icon{color:var(--mp-indigo);}
+.mptbm-search-box input{border:none;outline:none;box-shadow:none;font-size:13px;font-family:inherit;color:var(--mp-ink);width:100%;background:transparent;margin:0;min-height:auto;padding:0;}
+.mptbm-search-box input:focus{outline:none;box-shadow:none;border:none;}
+.mptbm-search-clear{display:none;align-items:center;justify-content:center;flex-shrink:0;width:20px;height:20px;border:none;border-radius:50%;background:var(--mp-bg);color:var(--mp-muted);cursor:pointer;padding:0;transition:background .15s,color .15s;}
+.mptbm-search-clear:hover{background:var(--mp-indigo-soft);color:var(--mp-indigo);}
+.mptbm-search-box.has-value .mptbm-search-clear{display:inline-flex;}
+
+/* CUSTOM DROPDOWN */
+.mptbm-filter-select{display:none;}
+.mptbm-dropdown{position:relative;font-family:inherit;}
+.mptbm-dropdown-toggle{display:inline-flex;align-items:center;gap:10px;min-width:160px;justify-content:space-between;background:var(--mp-white);border:1px solid var(--mp-border);border-radius:10px;padding:9px 14px;font-size:13px;font-weight:600;font-family:inherit;color:var(--mp-ink2);cursor:pointer;transition:border-color .2s,box-shadow .2s;}
+.mptbm-dropdown-toggle:hover{border-color:#cbd5e1;}
+.mptbm-dropdown.open .mptbm-dropdown-toggle{border-color:var(--mp-indigo);box-shadow:0 0 0 3px var(--mp-indigo-soft);}
+.mptbm-dropdown-toggle .mptbm-caret{transition:transform .2s;color:var(--mp-muted);flex-shrink:0;}
+.mptbm-dropdown.open .mptbm-dropdown-toggle .mptbm-caret{transform:rotate(180deg);}
+.mptbm-dropdown-menu{position:absolute;top:calc(100% + 6px);left:0;right:0;z-index:20;background:var(--mp-white);border:1px solid var(--mp-border);border-radius:12px;box-shadow:var(--mp-shadow-hover);padding:6px;opacity:0;visibility:hidden;transform:translateY(-6px);transition:opacity .18s,transform .18s,visibility .18s;max-height:280px;overflow-y:auto;}
+.mptbm-dropdown.open .mptbm-dropdown-menu{opacity:1;visibility:visible;transform:translateY(0);}
+.mptbm-dropdown-option{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 12px;border-radius:8px;font-size:13px;font-weight:600;color:var(--mp-ink2);cursor:pointer;transition:background .15s,color .15s;}
+.mptbm-dropdown-option:hover{background:var(--mp-bg);}
+.mptbm-dropdown-option.selected{background:var(--mp-indigo-soft);color:var(--mp-indigo);}
+.mptbm-dropdown-option .mptbm-check{opacity:0;transition:opacity .15s;}
+.mptbm-dropdown-option.selected .mptbm-check{opacity:1;}
+.mptbm-view-toggle{display:flex;gap:4px;background:var(--mp-white);padding:4px;border-radius:8px;border:1px solid var(--mp-border);margin-left:auto;}
+.mptbm-vtog{width:32px;height:32px;border:none;border-radius:6px;cursor:pointer;background:none;display:flex;align-items:center;justify-content:center;color:var(--mp-muted);transition:all .15s;}
+.mptbm-vtog.active{background:var(--mp-indigo);color:#fff;}
+
+/* GRID */
+.mptbm-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(290px,1fr));gap:18px;}
+.mptbm-card{background:var(--mp-white);border-radius:16px;border:1px solid var(--mp-border);overflow:hidden;transition:box-shadow .25s,transform .2s;animation:mptbmFadeUp .4s ease both;}
+.mptbm-card:hover{box-shadow:var(--mp-shadow-hover);transform:translateY(-3px);}
+@keyframes mptbmFadeUp{from{opacity:0;transform:translateY(16px);}to{opacity:1;transform:translateY(0);}}
+.mptbm-thumb{height:160px;position:relative;overflow:hidden;background:linear-gradient(135deg,#312e81,#4f46e5);}
+.mptbm-thumb img{width:100%;height:100%;object-fit:cover;display:block;transition:transform .4s;}
+.mptbm-card:hover .mptbm-thumb img{transform:scale(1.06);}
+.mptbm-thumb-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:rgba(255,255,255,.4);}
+.mptbm-thumb-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(15,23,42,.7) 0%,transparent 55%);}
+.mptbm-thumb-badges{position:absolute;top:12px;left:12px;display:flex;gap:6px;flex-wrap:wrap;max-width:85%;}
+.mptbm-thumb-badge{font-size:10px;font-weight:700;letter-spacing:.04em;padding:3px 9px;border-radius:6px;backdrop-filter:blur(6px);text-transform:uppercase;}
+.mptbm-thumb-badge.type{background:rgba(79,70,229,.9);color:#fff;}
+.mptbm-thumb-badge.alt{background:rgba(255,255,255,.9);color:var(--mp-ink);}
+.mptbm-actions-top{position:absolute;top:10px;right:10px;display:flex;gap:6px;opacity:0;transition:opacity .2s;z-index:3;}
+.mptbm-card:hover .mptbm-actions-top,.mptbm-card:focus-within .mptbm-actions-top{opacity:1;}
+.mptbm-act-btn{width:32px;height:32px;border-radius:9px;border:none;cursor:pointer;display:flex;align-items:center;justify-content:center;backdrop-filter:blur(6px);transition:background .15s,transform .15s;text-decoration:none;box-shadow:0 2px 6px rgba(15,23,42,.25);}
+.mptbm-act-btn:hover{transform:translateY(-1px);}
+.mptbm-act-btn.edit{background:rgba(255,255,255,.92);color:var(--mp-ink);}
+.mptbm-act-btn.edit:hover{background:#fff;}
+.mptbm-act-btn.del{background:rgba(239,68,68,.95);color:#fff;}
+.mptbm-act-btn.del:hover{background:#ef4444;}
+.mptbm-act-btn.restore{background:rgba(22,163,74,.95);color:#fff;}
+.mptbm-act-btn.restore:hover{background:var(--mp-green);}
+.mptbm-body{padding:16px;}
+.mptbm-name{display:block;font-size:16px;font-weight:700;color:var(--mp-ink) !important;margin-bottom:6px;line-height:1.3;text-decoration:none;}
+.mptbm-name:hover{color:var(--mp-indigo) !important;}
+.mptbm-location{display:flex;align-items:center;gap:5px;font-size:12px;color:var(--mp-muted);margin-bottom:12px;}
+.mptbm-location svg{flex-shrink:0;color:var(--mp-indigo);}
+.mptbm-meta-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-bottom:12px;}
+.mptbm-meta-cell{background:var(--mp-bg);border-radius:9px;padding:8px 10px;display:flex;flex-direction:column;gap:2px;}
+.mptbm-meta-k{font-size:9px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--mp-muted);}
+.mptbm-meta-v{font-size:12px;font-weight:700;color:var(--mp-ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.mptbm-footer{display:flex;align-items:center;justify-content:space-between;gap:8px;padding-top:12px;border-top:1px solid var(--mp-border);}
+.mptbm-author{font-size:11px;color:var(--mp-muted);display:flex;align-items:center;gap:5px;overflow:hidden;}
+.mptbm-author-avatar{width:22px;height:22px;border-radius:50%;background:var(--mp-indigo);display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:700;color:#fff;flex-shrink:0;}
+.mptbm-status-dot{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;white-space:nowrap;}
+.mptbm-status-dot::before{content:'';width:6px;height:6px;border-radius:50%;display:block;background:var(--mp-muted);}
+.mptbm-status-dot.status-publish{color:var(--mp-green);}
+.mptbm-status-dot.status-publish::before{background:var(--mp-green);}
+.mptbm-status-dot.status-draft{color:var(--mp-orange);}
+.mptbm-status-dot.status-draft::before{background:var(--mp-orange);}
+.mptbm-status-dot.status-pending{color:var(--mp-blue);}
+.mptbm-status-dot.status-pending::before{background:var(--mp-blue);}
+
+/* TABLE */
+.mptbm-table{width:100%;border-collapse:separate;border-spacing:0 8px;display:none;}
+.mptbm-table th{font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--mp-muted);padding:0 16px 4px;text-align:left;}
+.mptbm-table tr.mptbm-row{background:var(--mp-white);transition:box-shadow .2s,transform .15s;animation:mptbmFadeUp .35s ease both;}
+.mptbm-table tr.mptbm-row:hover{box-shadow:var(--mp-shadow-hover);transform:translateY(-2px);}
+.mptbm-table td{padding:14px 16px;font-size:13px;color:var(--mp-ink2);border-top:1px solid var(--mp-border);border-bottom:1px solid var(--mp-border);vertical-align:middle;}
+.mptbm-table td:first-child{border-left:1px solid var(--mp-border);border-radius:12px 0 0 12px;font-weight:700;}
+.mptbm-table td:first-child a{color:var(--mp-ink) !important;text-decoration:none;}
+.mptbm-table td:first-child a:hover{color:var(--mp-indigo) !important;}
+.mptbm-table td:last-child{border-right:1px solid var(--mp-border);border-radius:0 12px 12px 0;}
+.mptbm-table-edit,.mptbm-table-del{padding:4px 12px;border-radius:6px;border:1px solid var(--mp-border);background:var(--mp-white);font-size:11px;font-weight:600;cursor:pointer;text-decoration:none;color:var(--mp-ink2) !important;display:inline-block;}
+.mptbm-table-edit:hover{border-color:var(--mp-indigo);color:var(--mp-indigo) !important;}
+.mptbm-table-del{margin-left:4px;}
+.mptbm-table-del:hover{border-color:#ef4444;color:#ef4444 !important;}
+
+/* PAGINATION */
+.mptbm-pagination{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:24px;flex-wrap:wrap;}
+.mptbm-page-info{font-size:13px;color:var(--mp-muted);}
+.mptbm-page-btns{display:flex;gap:6px;flex-wrap:wrap;}
+.mptbm-page-btn{min-width:34px;height:34px;padding:0 8px;border-radius:8px;border:1px solid var(--mp-border);background:var(--mp-white);font-size:13px;font-weight:600;color:var(--mp-ink2);cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all .15s;font-family:inherit;}
+.mptbm-page-btn:hover:not(:disabled),.mptbm-page-btn.active{background:var(--mp-indigo);color:#fff;border-color:var(--mp-indigo);}
+.mptbm-page-btn:disabled{opacity:.4;cursor:not-allowed;}
+
+.mptbm-empty{display:none;text-align:center;padding:60px 20px;color:var(--mp-muted);font-size:14px;font-weight:500;}
+.mptbm-no-data{text-align:center;padding:60px 20px;color:var(--mp-muted);}
+.mptbm-no-data p{font-size:15px;margin-bottom:18px;}
+
+/* RESPONSIVE */
+@media (max-width:1200px){.mptbm-stats{grid-template-columns:repeat(2,1fr);}}
+@media (max-width:782px){
+  .mptbm-fleet{margin:10px 0 30px 0;padding:18px;border-radius:14px;}
+  .mptbm-view-toggle{margin-left:0;}
+  .mptbm-search-box{max-width:none;flex:1 1 100%;order:5;}
+  .mptbm-grid{grid-template-columns:1fr;}
+  .mptbm-table thead{display:none;}
+  .mptbm-table,.mptbm-table tbody,.mptbm-table tr.mptbm-row,.mptbm-table td{display:block;width:100%;}
+  .mptbm-table tr.mptbm-row{background:var(--mp-white);border:1px solid var(--mp-border);border-radius:12px;margin-bottom:12px;padding:6px 0;}
+  .mptbm-table td{border:none !important;border-radius:0 !important;padding:8px 16px;display:flex;justify-content:space-between;align-items:center;gap:12px;text-align:right;}
+  .mptbm-table td::before{content:attr(data-label);font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--mp-muted);text-align:left;}
 }
-
-.mptbm_transportation_lists_page_title{
-    font-size:30px !important;
-    line-height:1.2;
-    font-weight:700 !important;
-    margin:0 0 6px !important;
-    color:#101828;
-    letter-spacing:-0.5px;
-}
-
-.mptbm_transportation_lists_tabs{
-    display:flex;
-    align-items:center;
-    gap:16px;
-}
-
-.mptbm_transportation_lists_tabs a{
-    font-size:13px;
-    color:#667085;
-    text-decoration:none;
-    padding-bottom:5px;
-    transition:.2s;
-}
-
-.mptbm_transportation_lists_tabs a:hover{
-    color:#2f1fd1;
-}
-
-.mptbm_transportation_lists_tab_active{
-    color:#2f1fd1 !important;
-    border-bottom:2px solid #2f1fd1;
-    font-weight:600;
-}
-
-/* ===================================================
-   ADD BUTTON
-=================================================== */
-
-.mptbm_transportation_lists_add_btn{
-    height:42px;
-    padding:0 22px;
-    border-radius:8px;
-    background:linear-gradient(135deg,#2f1fd1,#4f46e5);
-    color:#fff !important;
-    display:inline-flex;
-    align-items:center;
-    justify-content:center;
-    gap:8px;
-    text-decoration:none;
-    font-size:13px;
-    font-weight:600;
-    box-shadow:0 10px 20px rgba(47,31,209,.18);
-    transition:.25s ease;
-}
-
-.mptbm_transportation_lists_add_btn:hover{
-    transform:translateY(-2px);
-    box-shadow:0 14px 28px rgba(47,31,209,.22);
-}
-
-.mptbm_transportation_lists_add_btn .dashicons{
-    font-size:15px;
-}
-
-/* ===================================================
-   STATS
-=================================================== */
-
-.mptbm_transportation_lists_stats_wrapper{
-    display:grid;
-    grid-template-columns:repeat(3,1fr);
-    gap:14px;
-    margin-bottom:16px;
-}
-
-.mptbm_transportation_lists_stats_card{
-    background:#fff;
-    border:1px solid #e7eaf3;
-    border-radius:14px;
-    padding:16px 18px;
-    display:flex;
-    align-items:center;
-    gap:14px;
-    transition:.25s ease;
-}
-
-.mptbm_transportation_lists_stats_card:hover{
-    transform:translateY(-2px);
-    box-shadow:0 10px 24px rgba(15,23,42,.05);
-}
-
-.mptbm_transportation_lists_stats_icon{
-    width:44px;
-    height:44px;
-    border-radius:12px;
-    background:#ede9fe;
-    display:flex;
-    align-items:center;
-    justify-content:center;
-}
-
-.mptbm_transportation_lists_stats_icon .dashicons{
-    color:#2f1fd1;
-    font-size:20px;
-}
-
-.mptbm_transportation_lists_stats_label{
-    font-size:10px;
-    color:#98a2b3;
-    font-weight:700;
-    letter-spacing:1px;
-    margin-bottom:3px;
-}
-
-.mptbm_transportation_lists_stats_value{
-    font-size:18px;
-    font-weight:700;
-    color:#111827;
-}
-
-/* ===================================================
-   FILTER BAR
-=================================================== */
-
-.mptbm_transportation_lists_filter_bar{
-    display:flex;
-    align-items:center;
-    justify-content:space-between;
-    padding:12px;
-    border-radius:12px;
-    background:#eef2ff;
-    margin-bottom:14px;
-}
-
-.mptbm_transportation_lists_filter_left{
-    display:flex;
-    align-items:center;
-    gap:10px;
-}
-
-.mptbm_transportation_lists_bulk_select{
-    width:120px;
-    height:36px;
-    border:1px solid #d0d5dd;
-    border-radius:8px;
-    background:#fff;
-    padding:0 12px;
-    font-size:12px;
-    color:#344054;
-}
-
-.mptbm_transportation_lists_apply_btn{
-    height:36px;
-    border:none;
-    border-radius:8px;
-    background:#fff;
-    padding:0 20px;
-    color:#2f1fd1;
-    font-size:12px;
-    font-weight:600;
-    cursor:pointer;
-    transition:.2s;
-}
-
-.mptbm_transportation_lists_apply_btn:hover{
-    background:#f8f9fc;
-}
-
-.mptbm_transportation_lists_search_box{
-    width:320px;
-    height:38px;
-    border:1px solid #d0d5dd;
-    border-radius:8px;
-    background:#fff;
-    display:flex;
-    align-items:center;
-    overflow:hidden;
-}
-
-.mptbm_transportation_lists_search_box .dashicons{
-    margin-left:10px;
-    color:#667085;
-    font-size:16px;
-}
-
-.mptbm_transportation_lists_search_box input{
-    flex:1;
-    border:none !important;
-    outline:none !important;
-    box-shadow:none !important;
-    background:transparent;
-    height:100%;
-    padding:0 10px;
-    font-size:13px;
-}
-
-.mptbm_transportation_lists_search_box button{
-    width:92px;
-    height:100%;
-    border:none;
-    background:#4338ca;
-    color:#fff;
-    font-size:12px;
-    font-weight:600;
-    cursor:pointer;
-    transition:.2s;
-}
-
-.mptbm_transportation_lists_search_box button:hover{
-    background:#3120cf;
-}
-
-/* ===================================================
-   CARD WRAPPER
-=================================================== */
-
-.mptbm_transportation_lists_cards_wrapper{
-    display:flex;
-    flex-direction:column;
-    gap:12px;
-}
-
-/* ===================================================
-   SINGLE CARD
-=================================================== */
-
-.mptbm_transportation_lists_card{
-    display:flex;
-    overflow:hidden;
-    /*min-height:180px;*/
-    border-radius:14px;
-    background:#fff;
-    border:1px solid #e4e7ec;
-    transition:.25s ease;
-}
-
-.mptbm_transportation_lists_card:hover{
-    transform:translateY(-2px);
-    box-shadow:0 16px 30px rgba(15,23,42,.06);
-}
-
-/* ===================================================
-   IMAGE
-=================================================== */
-
-.mptbm_transportation_lists_image_area{
-    width:190px;
-    position:relative;
-    flex-shrink:0;
-}
-
-.mptbm_transportation_lists_image_area img{
-    width:100%;
-    height:100%;
-    object-fit:cover;
-    display:block;
-}
-
-.mptbm_transportation_lists_badge{
-    position:absolute;
-    top:12px;
-    left:12px;
-    z-index:5;
-    padding:5px 10px;
-    border-radius:20px;
-    background:linear-gradient(135deg,#2f1fd1,#4f46e5);
-    color:#fff;
-    font-size:9px;
-    font-weight:700;
-    letter-spacing:.7px;
-}
-
-/* ===================================================
-   CONTENT
-=================================================== */
-
-.mptbm_transportation_lists_content{
-    flex:1;
-    padding:18px;
-    display:flex;
-    flex-direction:column;
-    justify-content:space-between;
-}
-
-.mptbm_transportation_lists_card_top{
-    display:flex;
-    align-items:flex-start;
-    justify-content:space-between;
-    gap:20px;
-}
-
-.mptbm_transportation_lists_vehicle_title{
-    font-size:17px;
-    line-height:1.3;
-    margin:0 0 6px;
-    color:#111827;
-    font-weight:700;
-    letter-spacing:-.3px;
-}
-
-.mptbm_transportation_lists_location{
-    display:flex;
-    align-items:center;
-    gap:4px;
-    color:#667085;
-    font-size:12px;
-}
-
-.mptbm_transportation_lists_location .dashicons{
-    color:#2f1fd1;
-    font-size:14px;
-}
-
-/* ===================================================
-   ACTION BUTTON
-=================================================== */
-
-.mptbm_transportation_lists_action_buttons{
-    display:flex;
-    align-items:center;
-    gap:8px;
-}
-
-.mptbm_transportation_lists_edit_btn,
-.mptbm_transportation_lists_delete_btn{
-    width:38px;
-    height:38px;
-    border-radius:8px;
-    background:#fff;
-    border:1px solid #e4e7ec;
-    display:flex;
-    align-items:center;
-    justify-content:center;
-    text-decoration:none;
-    transition:.2s ease;
-}
-
-.mptbm_transportation_lists_edit_btn:hover,
-.mptbm_transportation_lists_delete_btn:hover{
-    transform:translateY(-1px);
-    box-shadow:0 8px 18px rgba(15,23,42,.08);
-}
-
-.mptbm_transportation_lists_edit_btn .dashicons{
-    color:#2f1fd1;
-}
-
-.mptbm_transportation_lists_delete_btn .dashicons{
-    color:#b42318;
-}
-
-/* ===================================================
-   META BOX
-=================================================== */
-
-.mptbm_transportation_lists_meta_box{
-    display:grid;
-    grid-template-columns:repeat(4,1fr);
-    gap:10px;
-    padding:8px 10px;
-    border-radius:10px;
-    background:#f1f4fd;
-    margin-top:5px;
-}
-
-.mptbm_transportation_lists_meta_item{
-    padding:0 8px;
-}
-
-.mptbm_transportation_lists_meta_label{
-    font-size:9px;
-    color:#98a2b3;
-    font-weight:700;
-    letter-spacing:1px;
-    margin-bottom:7px;
-}
-
-.mptbm_transportation_lists_meta_value{
-    color:#2f1fd1;
-    font-size:13px;
-    font-weight:700;
-}
-
-.mptbm_transportation_lists_meta_value_black{
-    color:#111827;
-    font-size:13px;
-    font-weight:700;
-}
-
-.mptbm_transportation_lists_meta_status{
-    display:flex;
-    align-items:center;
-    gap:6px;
-    color:#12b76a;
-    font-size:13px;
-    font-weight:700;
-}
-
-.mptbm_transportation_lists_meta_status span{
-    width:8px;
-    height:8px;
-    border-radius:50%;
-    background:#12b76a;
-}
-
-/* ===================================================
-   FOOTER
-=================================================== */
-
-.mptbm_transportation_lists_footer{
-    margin-top:14px;
-    padding:12px 14px;
-    border-radius:12px;
-    background:#eef2ff;
-    display:flex;
-    align-items:center;
-    justify-content:space-between;
-}
-
-.mptbm_transportation_lists_footer_text{
-    font-size:12px;
-    color:#667085;
-}
-
-.mptbm_transportation_lists_pagination{
-    display:flex;
-    align-items:center;
-    gap:8px;
-}
-
-.mptbm_transportation_lists_pagination button{
-    width:30px;
-    height:30px;
-    border:none;
-    border-radius:6px;
-    background:#fff;
-    display:flex;
-    align-items:center;
-    justify-content:center;
-    cursor:pointer;
-}
-
-.mptbm_transportation_lists_pagination_text{
-    height:30px;
-    padding:0 16px;
-    border-radius:6px;
-    background:#fff;
-    display:flex;
-    align-items:center;
-    justify-content:center;
-    font-size:12px;
-    font-weight:600;
-    color:#344054;
-}
-
-/* ===================================================
-   RESPONSIVE
-=================================================== */
-
-@media(max-width:1200px){
-
-    .mptbm_transportation_lists_stats_wrapper{
-        grid-template-columns:1fr;
-    }
-
-    .mptbm_transportation_lists_meta_box{
-        grid-template-columns:repeat(4,1fr);
-    }
-}
-
-.mptbm_transportation_lists_meta_label .dashicons,
-.mptbm_transportation_lists_vehicle_title .dashicons,
-.mptbm_transportation_lists_badge .dashicons,
-.mptbm_transportation_lists_location .dashicons {
-    margin-right: 5px;
-    vertical-align: middle;
-}
-
-.mptbm_transportation_lists_pagination{
-    display:flex;
-    align-items:center;
-    gap:10px;
-}
-
-.mptbm_transportation_lists_pagination_text{
-    display:flex;
-    gap:8px;
-}
-
-.mptbm_pagination_number,
-.mptbm_pagination_btn{
-    width:36px;
-    height:36px;
-    display:flex;
-    align-items:center;
-    justify-content:center;
-    text-decoration:none;
-    border-radius:6px;
-    background:#f1f1f1;
-    color:#222;
-}
-
-.mptbm_pagination_number.active{
-    background:#2271b1;
-    color:#fff;
-}
-
-@media(max-width:768px){
-
-    .mptbm_transportation_lists_topbar,
-    .mptbm_transportation_lists_filter_bar,
-    .mptbm_transportation_lists_footer,
-    .mptbm_transportation_lists_card_top{
-        flex-direction:column;
-        align-items:flex-start;
-        gap:14px;
-    }
-
-    .mptbm_transportation_lists_card{
-        flex-direction:column;
-    }
-
-    .mptbm_transportation_lists_image_area{
-        width:100%;
-        height:220px;
-    }
-
-    .mptbm_transportation_lists_search_box{
-        width:100%;
-    }
-
-    .mptbm_transportation_lists_meta_box{
-        grid-template-columns:1fr;
-    }
+@media (max-width:480px){
+  .mptbm-stats{grid-template-columns:1fr;}
+  .mptbm-tab-pills{width:100%;justify-content:space-between;}
 }

--- a/assets/admin/mptbm_transportation_lists.js
+++ b/assets/admin/mptbm_transportation_lists.js
@@ -1,76 +1,186 @@
-jQuery(document).ready(function($){
+/* ==========================================================================
+   MPTBM Transportation - list interactions
+   View toggle, live search, custom type dropdown, status tabs, pagination.
+   ========================================================================== */
+(function () {
+	'use strict';
 
-    $('.mptbm_transportation_lists_card').on('mouseenter', function(){
+	document.addEventListener('DOMContentLoaded', function () {
+		var fleet = document.querySelector('.mptbm-fleet');
+		if (!fleet) { return; }
 
-        $(this).addClass('mptbm_transportation_lists_card_active');
+		var grid     = document.getElementById('mptbmGrid');
+		var table    = document.getElementById('mptbmTable');
+		var gridBtn  = document.getElementById('mptbmGridBtn');
+		var listBtn  = document.getElementById('mptbmListBtn');
+		var searchEl = document.getElementById('mptbmSearchInput');
+		var searchBox = searchEl ? searchEl.closest('.mptbm-search-box') : null;
+		var clearBtn = document.getElementById('mptbmSearchClear');
+		var typeEl   = document.getElementById('mptbmTypeFilter');
+		var emptyMsg = document.getElementById('mptbmEmptyMsg');
+		var pageInfo = document.getElementById('mptbmPageInfo');
+		var pageBtns = document.getElementById('mptbmPageBtns');
+		var tabs     = Array.prototype.slice.call(document.querySelectorAll('.mptbm-filter-pill'));
 
-    }).on('mouseleave', function(){
+		if (!grid) { return; }
 
-        $(this).removeClass('mptbm_transportation_lists_card_active');
+		var PER_PAGE = 12;
+		var STORE_KEY = 'mptbmTransportListView';
+		var cards = Array.prototype.slice.call(grid.querySelectorAll('.mptbm-card'));
+		var rows  = table ? Array.prototype.slice.call(table.querySelectorAll('tr.mptbm-row')) : [];
 
-    });
+		var state = { view: 'grid', search: '', type: '', status: '', page: 1 };
 
-    $('.mptbm_transportation_lists_search_box input').on('keyup', function(){
+		function applyView() {
+			var isGrid = state.view === 'grid';
+			grid.style.display = isGrid ? 'grid' : 'none';
+			if (table) { table.style.display = isGrid ? 'none' : 'table'; }
+			gridBtn.classList.toggle('active', isGrid);
+			listBtn.classList.toggle('active', !isGrid);
+		}
+		function setView(view) {
+			state.view = view;
+			try { window.localStorage.setItem(STORE_KEY, view); } catch (e) {}
+			applyView();
+			render();
+		}
+		try {
+			var saved = window.localStorage.getItem(STORE_KEY);
+			if (saved === 'list' || saved === 'grid') { state.view = saved; }
+		} catch (e) {}
+		gridBtn.addEventListener('click', function () { setView('grid'); });
+		listBtn.addEventListener('click', function () { setView('list'); });
 
-        var value = $(this).val().toLowerCase();
+		function matches(el) {
+			var name = (el.getAttribute('data-name') || '');
+			var type = (el.getAttribute('data-type') || '');
+			var status = (el.getAttribute('data-status') || '');
+			if (state.search && name.indexOf(state.search) === -1) { return false; }
+			if (state.type && type !== state.type) { return false; }
+			if (state.status && status !== state.status) { return false; }
+			return true;
+		}
 
-        $('.mptbm_transportation_lists_card').filter(function(){
+		function render() {
+			var items = state.view === 'list' ? rows : cards;
+			var matched = items.filter(matches);
+			var total = matched.length;
+			var pages = Math.max(1, Math.ceil(total / PER_PAGE));
+			if (state.page > pages) { state.page = pages; }
+			var start = (state.page - 1) * PER_PAGE;
+			var end = start + PER_PAGE;
 
-            $(this).toggle(
-                $(this).text().toLowerCase().indexOf(value) > -1
-            );
+			items.forEach(function (el) { el.style.display = 'none'; });
+			matched.forEach(function (el, i) { if (i >= start && i < end) { el.style.display = ''; } });
 
-        });
+			if (emptyMsg) { emptyMsg.style.display = total === 0 ? 'block' : 'none'; }
+			renderPageInfo(total, start, end);
+			renderPageButtons(pages);
+		}
+		function renderPageInfo(total, start, end) {
+			if (!pageInfo) { return; }
+			if (total === 0) { pageInfo.textContent = '0 items'; return; }
+			pageInfo.textContent = 'Showing ' + (start + 1) + '-' + Math.min(end, total) + ' of ' + total + ' items';
+		}
+		function makeBtn(label, page, opts) {
+			opts = opts || {};
+			var btn = document.createElement('button');
+			btn.className = 'mptbm-page-btn' + (opts.active ? ' active' : '');
+			btn.innerHTML = label;
+			if (opts.disabled) { btn.disabled = true; }
+			else {
+				btn.addEventListener('click', function () {
+					state.page = page; render();
+					fleet.scrollIntoView({ behavior: 'smooth', block: 'start' });
+				});
+			}
+			return btn;
+		}
+		function renderPageButtons(pages) {
+			if (!pageBtns) { return; }
+			pageBtns.innerHTML = '';
+			if (pages <= 1) { return; }
+			pageBtns.appendChild(makeBtn('&#8249;', state.page - 1, { disabled: state.page === 1 }));
+			for (var p = 1; p <= pages; p++) {
+				pageBtns.appendChild(makeBtn(String(p), p, { active: p === state.page }));
+			}
+			pageBtns.appendChild(makeBtn('&#8250;', state.page + 1, { disabled: state.page === pages }));
+		}
 
-    });
+		function resetAndRender() { state.page = 1; render(); }
 
+		/* ---- Live search ------------------------------------------------ */
+		if (searchEl) {
+			var onSearch = function () {
+				state.search = searchEl.value.toLowerCase().trim();
+				if (searchBox) { searchBox.classList.toggle('has-value', searchEl.value.length > 0); }
+				resetAndRender();
+			};
+			searchEl.addEventListener('input', onSearch);
+			searchEl.addEventListener('search', onSearch);
+			if (searchBox) {
+				searchEl.addEventListener('focus', function () { searchBox.classList.add('is-focused'); });
+				searchEl.addEventListener('blur', function () { searchBox.classList.remove('is-focused'); });
+			}
+			if (clearBtn) {
+				clearBtn.addEventListener('click', function () { searchEl.value = ''; searchEl.focus(); onSearch(); });
+			}
+		}
 
-    $(document).on('click', '.mptbm-trash-confirm', function (e) {
-        if (!confirm('Move this item to trash?')) {
-            e.preventDefault();
-        }
-    });
+		/* ---- Custom styled dropdown (type filter) ---------------------- */
+		function buildDropdown(select) {
+			var options = Array.prototype.slice.call(select.options);
+			var wrap = document.createElement('div');
+			wrap.className = 'mptbm-dropdown';
+			var toggle = document.createElement('button');
+			toggle.type = 'button';
+			toggle.className = 'mptbm-dropdown-toggle';
+			var label = document.createElement('span');
+			label.textContent = options[select.selectedIndex] ? options[select.selectedIndex].text : '';
+			var caret = document.createElement('span');
+			caret.className = 'mptbm-caret';
+			caret.innerHTML = '<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"/></svg>';
+			toggle.appendChild(label);
+			toggle.appendChild(caret);
+			var menu = document.createElement('div');
+			menu.className = 'mptbm-dropdown-menu';
+			menu.setAttribute('role', 'listbox');
+			var check = '<span class="mptbm-check"><svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.6" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg></span>';
+			options.forEach(function (opt) {
+				var item = document.createElement('div');
+				item.className = 'mptbm-dropdown-option' + (opt.value === select.value ? ' selected' : '');
+				item.innerHTML = '<span>' + opt.text + '</span>' + check;
+				item.addEventListener('click', function () {
+					select.value = opt.value;
+					label.textContent = opt.text;
+					menu.querySelectorAll('.mptbm-dropdown-option').forEach(function (o) { o.classList.remove('selected'); });
+					item.classList.add('selected');
+					wrap.classList.remove('open');
+					state.type = opt.value;
+					resetAndRender();
+				});
+				menu.appendChild(item);
+			});
+			toggle.addEventListener('click', function (e) { e.stopPropagation(); wrap.classList.toggle('open'); });
+			document.addEventListener('click', function (e) { if (!wrap.contains(e.target)) { wrap.classList.remove('open'); } });
+			document.addEventListener('keydown', function (e) { if (e.key === 'Escape') { wrap.classList.remove('open'); } });
+			wrap.appendChild(toggle);
+			wrap.appendChild(menu);
+			select.parentNode.insertBefore(wrap, select.nextSibling);
+		}
+		if (typeEl) { buildDropdown(typeEl); }
 
-    $(document).on('click', '.mptbm-delete-confirm', function (e) {
-        e.preventDefault();
+		/* ---- Status tabs ------------------------------------------------ */
+		tabs.forEach(function (tab) {
+			tab.addEventListener('click', function () {
+				tabs.forEach(function (t) { t.classList.remove('active'); });
+				this.classList.add('active');
+				state.status = this.getAttribute('data-status') || '';
+				resetAndRender();
+			});
+		});
 
-        let url = $(this).attr('href');
-
-        if (confirm('Delete this item permanently?')) {
-            window.location.href = url;
-        }
-    });
-
-    /*Search Fields*/
-    function filterCards() {
-
-        let value = $('#mptbm_search_input').val().toLowerCase();
-
-        $('.mptbm_transportation_lists_card').each(function () {
-
-            let title = $(this).data('transport-title').toLowerCase();
-
-            if (title.indexOf(value) > -1) {
-
-                // smooth show
-                $(this).stop(true, true).slideDown(250);
-
-            } else {
-
-                // smooth hide
-                $(this).stop(true, true).slideUp(250);
-            }
-        });
-    }
-
-    // live typing search
-    $(document).on('keyup','#mptbm_search_input', function () {
-        filterCards();
-    });
-
-    // button search
-    $(document).on('click','#mptbm_search_btn', function () {
-        filterCards();
-    });
-
-});
+		applyView();
+		render();
+	});
+})();


### PR DESCRIPTION


Rebuild the Transportation Lists screen (mptbm_transportation_lists) into the same modern, fully responsive card/table design used by the bus and rental plugins, themed in this plugin's own indigo palette (#4f46e5 / #2f1fd1 on slate) instead of red.

UI / design
- Header with item count + indigo "Add New Transportation" button.
- Stat cards: Active Fleet, Published, Draft, Revenue / mo (kept the existing current-month booking revenue stat).
- Card grid + table views populated from real meta: title, location, KM price, hourly price, model (from mptbm_features), featured image (indigo gradient fallback), price-based + transport-type badges, author initials, status.
- Hover-revealed Edit + Trash actions per card; modern responsive table that collapses to stacked cards on mobile.

Interactions (assets/admin/mptbm_transportation_lists.js)
- Persisted grid/list toggle, live search (title/location/model) with clear button, custom styled transport-type dropdown, status tabs (All/Published/ Draft) and client-side pagination (12/page). All items are loaded once and filtered client-side.

Trash management
- Trash tab renders trashed items inside the same design with per-item Restore and Delete Permanently actions; counts reflect wp_count_posts.

Security hardening
- The previous trash action (admin_post_mptbm_trash_transport) had no nonce. Added nonce verification + capability checks, and introduced matching nonce-protected Restore (mptbm_restore_transport) and Delete Permanently (mptbm_delete_transport) handlers that redirect back to the list.

Styling lives in the already-enqueued assets/admin/mptbm_transportation_lists .css (rewritten, scoped under .mptbm-fleet); no enqueue changes required.