### PR TITLE
chore: bump version to 2.0.4

### DIFF
--- a/MPTBM_Plugin.php
+++ b/MPTBM_Plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: E-cab Taxi Booking Manager for Woocommerce
  * Plugin URI: https://wordpress.org/plugins/ecab-taxi-booking-manager/
  * Description: A Complete Transportation Solution for WordPress by MagePeople.
- * Version: 2.0.3
+ * Version: 2.0.4
  * Author: MagePeople Team
  * Author URI: http://www.mage-people.com/
  * License: GPL v2 or later
@@ -49,7 +49,7 @@ if (!class_exists('MPTBM_Plugin')) {
                 // define('MPTBM_PLUGIN_DATA', get_plugin_data(__FILE__));
             }
             if (!defined('MPTBM_PLUGIN_VERSION')) {
-                define('MPTBM_PLUGIN_VERSION', '1.2.1');
+                define('MPTBM_PLUGIN_VERSION', '2.0.4');
             }
 
             // Create required directories if they don't exist


### PR DESCRIPTION
Releases MP_Global_Function::format_price() (added in 325a7e4), which the Pro plugin's native checkout, booking mails and PDF ticket call. The 2.0.3 release line predates that commit, so sites on free 2.0.3 + current Pro hit 'Call to undefined method MP_Global_Function::format_price()' on add-to-cart. Also syncs the stale MPTBM_PLUGIN_VERSION constant (was 1.2.1) with the plugin header.