### PR TITLE
Modernize taxi admin UX and fix session-start warnings

### DIFF
--- a/Admin/MPTBM_Dummy_Import.php
+++ b/Admin/MPTBM_Dummy_Import.php
@@ -13,9 +13,8 @@ if (!class_exists('MPTBM_Dummy_Import')) {
 		public function __construct()
 		{
 			add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
-			add_action('admin_footer', array($this, 'render_popup'));
+			add_action('admin_footer', array($this, 'render_widget'));
 			add_action('wp_ajax_mptbm_import_dummy_data', array($this, 'ajax_import_dummy_data'));
-			add_action('wp_ajax_mptbm_dismiss_dummy_import', array($this, 'ajax_dismiss_dummy_import'));
 		}
 
 		/**
@@ -34,7 +33,12 @@ if (!class_exists('MPTBM_Dummy_Import')) {
 			return (int) wp_count_posts('mptbm_rent')->publish === 0;
 		}
 
-		/** Limit the popup to our own admin screens + dashboard. */
+		/**
+		 * Limit the auto-import widget to the plugin's own admin screens.
+		 * Since the demo data now imports automatically (no confirmation),
+		 * we intentionally keep it inside the Taxi Booking Manager area and
+		 * off the global WP Dashboard.
+		 */
 		private function is_relevant_screen(): bool
 		{
 			$screen = get_current_screen();
@@ -44,17 +48,7 @@ if (!class_exists('MPTBM_Dummy_Import')) {
 			return (
 				strpos($screen->id, 'mptbm') !== false
 				|| $screen->post_type === 'mptbm_rent'
-				|| $screen->id === 'dashboard'
 			);
-		}
-
-		/** Whether the popup should pop open by itself (vs. wait for a manual trigger). */
-		private function should_auto_show_popup(): bool
-		{
-			if (!$this->is_eligible()) {
-				return false;
-			}
-			return get_option('mptbm_dummy_import_dismissed') !== 'yes';
 		}
 
 		public function enqueue_assets(): void
@@ -83,73 +77,64 @@ if (!class_exists('MPTBM_Dummy_Import')) {
 				true
 			);
 			wp_localize_script('mptbm-demo-import', 'mptbm_demo_import', array(
-				'ajax_url'      => admin_url('admin-ajax.php'),
-				'import_nonce'  => wp_create_nonce('mptbm_import_dummy'),
-				'dismiss_nonce' => wp_create_nonce('mptbm_dismiss_dummy'),
-				'i18n'          => array(
-					'importing'     => __('Importing demo data. This may take a moment...', 'ecab-taxi-booking-manager'),
-					'success'       => __('Demo data imported! Reloading...', 'ecab-taxi-booking-manager'),
+				'ajax_url'     => admin_url('admin-ajax.php'),
+				'import_nonce' => wp_create_nonce('mptbm_import_dummy'),
+				'i18n'         => array(
+					'title'         => __('Setting up demo data', 'ecab-taxi-booking-manager'),
+					'preparing'     => __('Preparing your demo workspace…', 'ecab-taxi-booking-manager'),
+					'importing'     => __('Importing sample transports & locations…', 'ecab-taxi-booking-manager'),
+					'finishing'     => __('Almost there, finishing up…', 'ecab-taxi-booking-manager'),
 					'success_title' => __('All set!', 'ecab-taxi-booking-manager'),
-					'error'         => __('Import failed. Please try again.', 'ecab-taxi-booking-manager'),
+					'success'       => __('Demo data ready — reloading…', 'ecab-taxi-booking-manager'),
+					'error_title'   => __('Import failed', 'ecab-taxi-booking-manager'),
+					'error'         => __('Something went wrong. Please try again.', 'ecab-taxi-booking-manager'),
+					'retry'         => __('Retry', 'ecab-taxi-booking-manager'),
 				),
 			));
 		}
 
-		public function render_popup(): void
+		/**
+		 * Renders the modern bottom-right progress widget. On a fresh install
+		 * with no transports yet, the demo data imports automatically and this
+		 * radial progress ring reports its status — no blocking modal.
+		 */
+		public function render_widget(): void
 		{
 			if (!$this->is_eligible() || !$this->is_relevant_screen()) {
 				return;
 			}
-			$display_style = $this->should_auto_show_popup() ? '' : 'display:none;';
 			?>
-			<div id="mptbm-demo-overlay" class="mptbm-inst-overlay" style="<?php echo esc_attr($display_style); ?>">
-				<div class="mptbm-inst-popup">
-					<div class="mptbm-inst-header">
-						<div class="mptbm-inst-header-icon">
-							<svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-								<path d="M3 13l2-5h11l2 5M5 13h14v5H5z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-								<circle cx="8" cy="18" r="1.6" stroke="currentColor" stroke-width="2"/>
-								<circle cx="16" cy="18" r="1.6" stroke="currentColor" stroke-width="2"/>
-							</svg>
-						</div>
-						<span class="mptbm-inst-header-text"><?php esc_html_e('Taxi Booking Manager', 'ecab-taxi-booking-manager'); ?></span>
-					</div>
+			<div id="mptbm-demo-widget" class="mptbm-dw" role="status" aria-live="polite">
+				<button type="button" class="mptbm-dw-close" id="mptbm-dw-close" aria-label="<?php esc_attr_e('Dismiss', 'ecab-taxi-booking-manager'); ?>">
+					<svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M3 3l8 8M11 3l-8 8" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+				</button>
 
-					<div class="mptbm-inst-icon-wrapper">
-						<div class="mptbm-inst-icon">
-							<svg width="40" height="40" viewBox="0 0 24 24" fill="none">
-								<path d="M4 7h16M4 12h16M4 17h10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-							</svg>
-						</div>
-					</div>
+				<div class="mptbm-dw-ring">
+					<svg class="mptbm-dw-svg" width="66" height="66" viewBox="0 0 80 80" aria-hidden="true">
+						<defs>
+							<linearGradient id="mptbmDwGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+								<stop offset="0%" stop-color="#1f6feb"/>
+								<stop offset="100%" stop-color="#4f46e5"/>
+							</linearGradient>
+						</defs>
+						<circle class="mptbm-dw-track" cx="40" cy="40" r="34"/>
+						<circle class="mptbm-dw-arc" id="mptbm-dw-arc" cx="40" cy="40" r="34"/>
+					</svg>
+					<span class="mptbm-dw-pct" id="mptbm-dw-pct">0%</span>
+					<span class="mptbm-dw-mark" aria-hidden="true">
+						<svg width="26" height="26" viewBox="0 0 24 24" fill="none"><path d="M6 12.5l3.5 3.5L18 7.5" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+					</span>
+				</div>
 
-					<div class="mptbm-inst-content">
-						<h2 class="mptbm-inst-title"><?php esc_html_e('Import Demo Data?', 'ecab-taxi-booking-manager'); ?></h2>
-						<p class="mptbm-inst-desc">
-							<?php esc_html_e('Want to see how Taxi Booking Manager works? We can import sample transports, locations, and settings so you can explore a fully configured setup right away.', 'ecab-taxi-booking-manager'); ?>
-						</p>
+				<div class="mptbm-dw-body">
+					<div class="mptbm-dw-brand">
+						<span class="mptbm-dw-brand-icon" aria-hidden="true">
+							<svg width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M3 13l2-5h11l2 5M5 13h14v5H5z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><circle cx="8" cy="18" r="1.5" stroke="currentColor" stroke-width="2"/><circle cx="16" cy="18" r="1.5" stroke="currentColor" stroke-width="2"/></svg>
+						</span>
+						<span class="mptbm-dw-title" id="mptbm-dw-title"><?php esc_html_e('Setting up demo data', 'ecab-taxi-booking-manager'); ?></span>
 					</div>
-
-					<div id="mptbm-demo-progress" class="mptbm-inst-progress" style="display:none;">
-						<div class="mptbm-inst-progress-bar">
-							<div id="mptbm-demo-progress-fill" class="mptbm-inst-progress-fill"></div>
-						</div>
-						<p id="mptbm-demo-status-text" class="mptbm-inst-status-text"></p>
-					</div>
-
-					<div class="mptbm-inst-actions">
-						<button type="button" id="mptbm-demo-import-btn" class="mptbm-inst-btn mptbm-inst-btn-primary">
-							<span class="mptbm-inst-btn-icon">
-								<svg width="18" height="18" viewBox="0 0 20 20" fill="none">
-									<path d="M10 3v10m0 0l-4-4m4 4l4-4M3 17h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-								</svg>
-							</span>
-							<span class="mptbm-inst-btn-text"><?php esc_html_e('Yes, Import Demo Data', 'ecab-taxi-booking-manager'); ?></span>
-						</button>
-						<button type="button" id="mptbm-demo-dismiss-btn" class="mptbm-inst-btn mptbm-inst-btn-secondary">
-							<?php esc_html_e('No, Start Fresh', 'ecab-taxi-booking-manager'); ?>
-						</button>
-					</div>
+					<p class="mptbm-dw-status" id="mptbm-dw-status"><?php esc_html_e('Preparing your demo workspace…', 'ecab-taxi-booking-manager'); ?></p>
+					<button type="button" class="mptbm-dw-retry" id="mptbm-dw-retry"><?php esc_html_e('Retry', 'ecab-taxi-booking-manager'); ?></button>
 				</div>
 			</div>
 			<?php
@@ -168,16 +153,6 @@ if (!class_exists('MPTBM_Dummy_Import')) {
 				@set_time_limit(300);
 			}
 			$this->dummy_import();
-			wp_send_json_success();
-		}
-
-		public function ajax_dismiss_dummy_import(): void
-		{
-			check_ajax_referer('mptbm_dismiss_dummy', 'nonce');
-			if (!current_user_can('manage_options')) {
-				wp_send_json_error(array('message' => __('Permission denied.', 'ecab-taxi-booking-manager')));
-			}
-			update_option('mptbm_dummy_import_dismissed', 'yes');
 			wp_send_json_success();
 		}
 

--- a/Admin/MPTBM_Payment_Notice.php
+++ b/Admin/MPTBM_Payment_Notice.php
@@ -27,17 +27,95 @@
 				if (!$this->should_show_notice()) {
 					return;
 				}
+				$this->print_styles_once();
+
+				$payments_url = admin_url('edit.php?post_type=' . MPTBM_Function::get_cpt() . '&page=mptbm_settings_page&mptbm_tab=payments');
+				$pro_active   = class_exists('MPTBM_Plugin_Pro');
 				?>
-				<div class="notice notice-warning is-dismissible">
-					<p>
-						<strong><?php esc_html_e('E-cab Taxi Booking Manager', 'ecab-taxi-booking-manager'); ?>:</strong>
-						<?php echo esc_html($this->get_notice_message()); ?>
-					</p>
-					<?php $links = $this->get_action_links(); ?>
-					<?php if (!empty($links)) : ?>
-						<p><?php echo wp_kses_post(implode(' &nbsp;|&nbsp; ', $links)); ?></p>
-					<?php endif; ?>
+				<div class="notice is-dismissible mptbm-pay-notice">
+					<div class="mptbm-pn-inner">
+						<span class="mptbm-pn-icon" aria-hidden="true">
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2.5"/><line x1="2" y1="10" x2="22" y2="10"/><line x1="6" y1="15" x2="10" y2="15"/></svg>
+						</span>
+						<div class="mptbm-pn-body">
+							<div class="mptbm-pn-title">
+								<?php esc_html_e('E-cab Taxi Booking Manager — payment setup needed', 'ecab-taxi-booking-manager'); ?>
+							</div>
+							<p class="mptbm-pn-text"><?php echo esc_html($this->get_notice_message()); ?></p>
+
+							<div class="mptbm-pn-actions">
+								<a class="mptbm-pn-btn mptbm-pn-btn-primary" href="<?php echo esc_url($payments_url); ?>">
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+									<?php esc_html_e('Go to Payment Settings', 'ecab-taxi-booking-manager'); ?>
+								</a>
+
+								<?php if (MPTBM_Function::is_wc_active()) : ?>
+									<span class="mptbm-pn-hint"><?php esc_html_e('Enable a WooCommerce gateway there.', 'ecab-taxi-booking-manager'); ?></span>
+								<?php else : ?>
+									<span class="mptbm-pn-hint"><?php esc_html_e('Activate WooCommerce or enable Custom Payment there.', 'ecab-taxi-booking-manager'); ?></span>
+								<?php endif; ?>
+							</div>
+
+							<?php if (!$pro_active) : ?>
+								<div class="mptbm-pn-pro-row">
+									<span class="mptbm-pn-pro-chip"><?php esc_html_e('PRO', 'ecab-taxi-booking-manager'); ?></span>
+									<span class="mptbm-pn-pro-text"><?php esc_html_e('Want more gateways (Stripe, PayPal, offline) without WooCommerce?', 'ecab-taxi-booking-manager'); ?></span>
+									<a class="mptbm-pn-pro-link" href="https://mage-people.com/product/wordpress-taxi-cab-booking-plugin-for-woocommerce" target="_blank" rel="noopener noreferrer">
+										<?php esc_html_e('Explore Pro', 'ecab-taxi-booking-manager'); ?> &rarr;
+									</a>
+								</div>
+							<?php endif; ?>
+						</div>
+					</div>
 				</div>
+				<?php
+			}
+
+			/** Scoped CSS for the modern notice, printed at most once per request. */
+			private function print_styles_once(): void {
+				static $printed = false;
+				if ($printed) {
+					return;
+				}
+				$printed = true;
+				?>
+				<style>
+				.mptbm-pay-notice{
+					border:1px solid #e9d7bd !important;border-left:4px solid #f59e0b !important;
+					border-radius:12px !important;background:#fff !important;padding:0 !important;
+					margin:16px 20px 14px 0 !important;box-shadow:0 4px 16px rgba(16,24,40,.07) !important;overflow:hidden;
+				}
+				.mptbm-pn-inner{display:flex;gap:14px;align-items:flex-start;padding:16px 40px 16px 18px;
+					font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,sans-serif;}
+				.mptbm-pn-icon{flex:0 0 auto;width:40px;height:40px;border-radius:11px;
+					background:linear-gradient(135deg,#fff7ed,#ffedd5);color:#d97706;border:1px solid #fed7aa;
+					display:flex;align-items:center;justify-content:center;}
+				.mptbm-pn-icon svg{width:20px;height:20px;display:block;}
+				.mptbm-pn-body{flex:1;min-width:0;}
+				.mptbm-pn-title{font-size:14px;font-weight:700;color:#1e293b;margin:1px 0 4px;line-height:1.3;}
+				.mptbm-pn-text{font-size:13px;color:#50575e;margin:0 0 12px;line-height:1.55;max-width:840px;}
+				.mptbm-pn-actions{display:flex;flex-wrap:wrap;align-items:center;gap:12px;}
+				.mptbm-pn-btn{display:inline-flex;align-items:center;gap:7px;height:34px;padding:0 16px;border-radius:8px;
+					font-size:13px;font-weight:600;text-decoration:none;line-height:1;box-sizing:border-box;
+					cursor:pointer;transition:all .18s ease;}
+				.mptbm-pn-btn svg{width:15px;height:15px;display:block;}
+				.mptbm-pn-btn-primary{background:#4f46e5;color:#fff !important;border:1px solid #4f46e5;
+					box-shadow:0 1px 3px rgba(79,70,229,.3);}
+				.mptbm-pn-btn-primary:hover{background:#4338ca;border-color:#4338ca;transform:translateY(-1px);
+					box-shadow:0 4px 10px rgba(79,70,229,.32);color:#fff !important;}
+				.mptbm-pn-hint{font-size:12px;color:#64748b;}
+				.mptbm-pn-pro-row{display:flex;flex-wrap:wrap;align-items:center;gap:9px;margin-top:12px;padding-top:12px;
+					border-top:1px dashed #eceff3;}
+				.mptbm-pn-pro-chip{display:inline-flex;align-items:center;background:#f59e0b;color:#fff;font-weight:800;
+					font-size:9px;letter-spacing:.07em;padding:3px 8px;border-radius:20px;text-transform:uppercase;}
+				.mptbm-pn-pro-text{font-size:12px;color:#64748b;}
+				.mptbm-pn-pro-link{font-size:12px;font-weight:700;color:#b45309 !important;text-decoration:none;}
+				.mptbm-pn-pro-link:hover{color:#92400e !important;text-decoration:underline;}
+				@media (max-width:782px){
+					.mptbm-pay-notice{margin-right:10px !important;}
+					.mptbm-pn-inner{padding-right:34px;}
+				}
+				</style>
 				<?php
 			}
 
@@ -66,22 +144,22 @@
 			 */
 			private function get_notice_message(): string {
 				if (!class_exists('MPTBM_Booking_Mode')) {
-					return __('No payment method is currently available. Customers will not be able to complete bookings until at least one payment method is enabled.', 'ecab-taxi-booking-manager');
+					return __('No payment method is set up yet, so customers can\'t complete a booking. Activate WooCommerce or enable a Custom Payment method in Payment Settings to start taking bookings.', 'ecab-taxi-booking-manager');
 				}
 
 				if (MPTBM_Booking_Mode::needs_selection()) {
-					return __('A Booking Mode hasn\'t been chosen yet (WooCommerce or Custom Payment). Choose one in Payments settings so bookings have a single, deterministic checkout path.', 'ecab-taxi-booking-manager');
+					return __('A Booking Mode hasn\'t been chosen yet. Pick WooCommerce or Custom Payment in Payment Settings so every booking follows one clear checkout path.', 'ecab-taxi-booking-manager');
 				}
 
 				if ('none' === MPTBM_Booking_Mode::availability()) {
-					return __('No payment method is currently available. Customers will not be able to complete bookings until at least one payment method is enabled.', 'ecab-taxi-booking-manager');
+					return __('No payment method is set up yet, so customers can\'t complete a booking. Activate WooCommerce or enable a Custom Payment method in Payment Settings to start taking bookings.', 'ecab-taxi-booking-manager');
 				}
 
 				if (MPTBM_Booking_Mode::is_woocommerce()) {
-					return __('Booking Mode is set to WooCommerce, but no WooCommerce payment gateway is enabled. Customers will not be able to complete a booking until one is enabled.', 'ecab-taxi-booking-manager');
+					return __('Booking Mode is set to WooCommerce, but no WooCommerce payment gateway is enabled yet. Enable one in Payment Settings so customers can complete a booking.', 'ecab-taxi-booking-manager');
 				}
 
-				return __('Booking Mode is set to Custom Payment, but no gateway (PayPal, Stripe, or Offline) is enabled. Customers will not be able to complete a booking until one is enabled.', 'ecab-taxi-booking-manager');
+				return __('Booking Mode is set to Custom Payment, but no gateway (PayPal, Stripe, or Offline) is enabled yet. Enable one in Payment Settings so customers can complete a booking.', 'ecab-taxi-booking-manager');
 			}
 
 			/**
@@ -102,40 +180,6 @@
 				);
 			}
 
-			/**
-			 * Contextual action links: only offer to configure the providers that
-			 * are actually present, and offer an upgrade link when Pro is missing.
-			 *
-			 * @return string[]
-			 */
-			private function get_action_links(): array {
-				$links = array();
-				$settings_url = admin_url('edit.php?post_type=' . MPTBM_Function::get_cpt() . '&page=mptbm_settings_page');
-
-				if (MPTBM_Function::is_wc_active()) {
-					$links[] = sprintf(
-						'<a href="%1$s">%2$s</a>',
-						esc_url($settings_url),
-						esc_html__('Configure WooCommerce Payments', 'ecab-taxi-booking-manager')
-					);
-				}
-
-				if (class_exists('MPTBM_Plugin_Pro')) {
-					$links[] = sprintf(
-						'<a href="%1$s">%2$s</a>',
-						esc_url($settings_url),
-						esc_html__('Configure Pro Payment Methods', 'ecab-taxi-booking-manager')
-					);
-				} else {
-					$links[] = sprintf(
-						'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
-						esc_url('https://mage-people.com/'),
-						esc_html__('Upgrade to Pro', 'ecab-taxi-booking-manager')
-					);
-				}
-
-				return $links;
-			}
 		}
 		new MPTBM_Payment_Notice();
 	}

--- a/Admin/MPTBM_Rent_Custom_Editor.php
+++ b/Admin/MPTBM_Rent_Custom_Editor.php
@@ -12,6 +12,7 @@ if (!class_exists('MPTBM_Rent_Custom_Editor')) {
         public function __construct() {
             add_action('admin_menu', [$this, 'register_menu']);
             add_action('admin_post_save_mptbm_rent', [$this, 'save_post']);
+            add_action('wp_ajax_mptbm_ajax_save_rent', [$this, 'ajax_save_rent']);
             add_action('admin_init', [$this, 'redirect_default_editor']);
             add_action('admin_init', [$this, 'redirect_add_new']);
 
@@ -286,7 +287,7 @@ if (!class_exists('MPTBM_Rent_Custom_Editor')) {
                     </div>
                 </div>
 
-                <form class="mptbm_rent_form" method="post" action="<?php echo admin_url('admin-post.php'); ?>">
+                <form class="mptbm_rent_form" method="post" action="<?php echo admin_url('admin-post.php'); ?>" novalidate>
 
                     <input type="hidden" name="editor_type" value="custom">
 
@@ -295,7 +296,28 @@ if (!class_exists('MPTBM_Rent_Custom_Editor')) {
                     <input type="hidden" name="post_id" value="<?php echo esc_attr($post_id); ?>">
 
                     <?php wp_nonce_field('save_mptbm_rent_nonce');
-                    $add_url   = admin_url('admin.php?page=mptbm-rent-edit');
+                    $add_url = admin_url('admin.php?page=mptbm-rent-edit');
+                    $list_url = admin_url('admin.php?page=mptbm_transportation_lists');
+
+                    // Status pill next to the title.
+                    switch (get_post_status($post_id)) {
+                        case 'publish':
+                            $status_slug = 'publish';
+                            $status_label = __('Published', 'ecab-taxi-booking-manager');
+                            break;
+                        case 'pending':
+                            $status_slug = 'pending';
+                            $status_label = __('Pending', 'ecab-taxi-booking-manager');
+                            break;
+                        case 'private':
+                            $status_slug = 'private';
+                            $status_label = __('Private', 'ecab-taxi-booking-manager');
+                            break;
+                        default:
+                            $status_slug = 'draft';
+                            $status_label = __('Draft', 'ecab-taxi-booking-manager');
+                            break;
+                    }
                     ?>
 
                     <!-- FIXED HEADER -->
@@ -303,35 +325,34 @@ if (!class_exists('MPTBM_Rent_Custom_Editor')) {
 
                         <div class="mptbm_fixed_header_top">
 
-                            <div class="">
-                                <a class="mptbm-link" href="<?php echo admin_url('admin.php?page=mptbm_transportation_lists'); ?>">
-                                    <span class="dashicons dashicons-arrow-left-alt"></span>
-                                    <?php esc_html_e( 'Back to Transports', 'ecab-taxi-booking-manager' ); ?>
+                            <div class="mptbm_header_lead">
+                                <a class="mptbm_back_btn" href="<?php echo esc_url($list_url); ?>" title="<?php esc_attr_e('Back to Transports', 'ecab-taxi-booking-manager'); ?>" aria-label="<?php esc_attr_e('Back to Transports', 'ecab-taxi-booking-manager'); ?>">
+                                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
                                 </a>
 
-                                <a class="mptbm-add-btn" href="<?php echo esc_url($add_url); ?>">
-                                    <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                                    <?php esc_html_e('Add New Transportation', 'ecab-taxi-booking-manager'); ?>
-                                </a>
-                            </div>
-
-
-
-                            <div class="mptbm_header_left">
-                                <h1 class="mptbm_page_title">
-                                    <?php echo esc_html($title); ?>
-                                </h1>
+                                <div class="mptbm_header_titlewrap">
+                                    <span class="mptbm_header_eyebrow">
+                                        <?php esc_html_e('Transportation', 'ecab-taxi-booking-manager'); ?>
+                                        <span class="mptbm_status_pill is-<?php echo esc_attr($status_slug); ?>"><?php echo esc_html($status_label); ?></span>
+                                    </span>
+                                    <h1 class="mptbm_page_title">
+                                        <?php echo esc_html($title ? $title : __('Untitled transportation', 'ecab-taxi-booking-manager')); ?>
+                                    </h1>
+                                </div>
                             </div>
 
                             <div class="mptbm_header_right">
-
-                                <?php
-                                submit_button($post_id ? 'Update' : 'Publish', 'primary', '', false); ?>
-                                
-                                <a href="<?php echo esc_url($old_editor_url); ?>" class="button">
-                                    <?php esc_html_e( 'Open classic Editor', 'ecab-taxi-booking-manager' ); ?>
+                                <a class="mptbm-add-btn" href="<?php echo esc_url($add_url); ?>" title="<?php esc_attr_e('Add New Transportation', 'ecab-taxi-booking-manager'); ?>">
+                                    <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                    <span class="mptbm_btn_label"><?php esc_html_e('Add New', 'ecab-taxi-booking-manager'); ?></span>
                                 </a>
 
+                                <a href="<?php echo esc_url($old_editor_url); ?>" class="button mptbm_btn_ghost" title="<?php esc_attr_e('Open classic Editor', 'ecab-taxi-booking-manager'); ?>">
+                                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                                    <span class="mptbm_btn_label"><?php esc_html_e('Classic Editor', 'ecab-taxi-booking-manager'); ?></span>
+                                </a>
+
+                                <?php submit_button($post_id ? __('Update', 'ecab-taxi-booking-manager') : __('Publish', 'ecab-taxi-booking-manager'), 'primary', '', false); ?>
                             </div>
 
                         </div>
@@ -3371,18 +3392,16 @@ if (!class_exists('MPTBM_Rent_Custom_Editor')) {
             }
         }
 
-        // 3. Save / Update post
-        public function save_post() {
-
-            if (
-                !isset($_POST['_wpnonce']) ||
-                !wp_verify_nonce($_POST['_wpnonce'], 'save_mptbm_rent_nonce')
-            ) {
-                wp_die('Security check failed');
-            }
-
-            $post_id = intval($_POST['post_id']);
-            $title   =  isset($_POST['post_title'] ) ? sanitize_text_field($_POST['post_title']) : 'TEst';
+        /**
+         * Core save routine shared by the classic (redirect) and AJAX handlers.
+         * Runs wp_update_post so every registered save_post hook (general,
+         * price, date, base-price, tax, extra services...) persists its own
+         * $_POST fields, then stores the manual route table. Returns the post
+         * ID on success or a WP_Error/0 on failure.
+         */
+        private function persist_rent() {
+            $post_id = isset($_POST['post_id']) ? intval($_POST['post_id']) : 0;
+            $title   = isset($_POST['post_title']) ? sanitize_text_field(wp_unslash($_POST['post_title'])) : '';
 
             $data = [
                 'post_title'  => $title,
@@ -3392,9 +3411,13 @@ if (!class_exists('MPTBM_Rent_Custom_Editor')) {
 
             if ($post_id) {
                 $data['ID'] = $post_id;
-                $post_id = wp_update_post($data);
+                $post_id = wp_update_post($data, true);
             } else {
-                $post_id = wp_insert_post($data);
+                $post_id = wp_insert_post($data, true);
+            }
+
+            if (is_wp_error($post_id) || !$post_id) {
+                return $post_id;
             }
 
             // Save manual routes
@@ -3416,8 +3439,76 @@ if (!class_exists('MPTBM_Rent_Custom_Editor')) {
             }
             update_post_meta($post_id, 'mptbm_terms_price_info', $terms_price_infos);
 
+            return $post_id;
+        }
+
+        // 3. Save / Update post (classic full-page submit fallback — no JS).
+        public function save_post() {
+
+            if (
+                !isset($_POST['_wpnonce']) ||
+                !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['_wpnonce'])), 'save_mptbm_rent_nonce')
+            ) {
+                wp_die('Security check failed');
+            }
+            if (!current_user_can('manage_options')) {
+                wp_die('You are not allowed to do this.');
+            }
+
+            $post_id = $this->persist_rent();
+            if (is_wp_error($post_id) || !$post_id) {
+                wp_die('Could not save transportation. Please go back and try again.');
+            }
+
             wp_redirect(admin_url('admin.php?page=mptbm-rent-edit&post_id=' . $post_id . '&updated=1'));
             exit;
+        }
+
+        /**
+         * AJAX save — used by the editor for instant, reload-free updates.
+         * Returns a translated success/error JSON payload the frontend turns
+         * into a toast. Validates the one hard-required field (Rent Title)
+         * server-side as a safety net behind the client-side check.
+         */
+        public function ajax_save_rent() {
+
+            if (
+                !isset($_POST['_wpnonce']) ||
+                !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['_wpnonce'])), 'save_mptbm_rent_nonce')
+            ) {
+                wp_send_json_error(['message' => __('Security check failed. Please refresh the page and try again.', 'ecab-taxi-booking-manager')]);
+            }
+            if (!current_user_can('manage_options')) {
+                wp_send_json_error(['message' => __('You are not allowed to do this.', 'ecab-taxi-booking-manager')]);
+            }
+
+            $title = isset($_POST['post_title']) ? trim(sanitize_text_field(wp_unslash($_POST['post_title']))) : '';
+            if ($title === '') {
+                wp_send_json_error([
+                    'message' => __('Rent Title is required.', 'ecab-taxi-booking-manager'),
+                    'field'   => 'post_title',
+                    'step'    => 1,
+                ]);
+            }
+
+            if (function_exists('wp_raise_memory_limit')) {
+                wp_raise_memory_limit('admin');
+            }
+
+            $post_id = $this->persist_rent();
+            if (is_wp_error($post_id) || !$post_id) {
+                $message = is_wp_error($post_id) ? $post_id->get_error_message() : __('Could not save. Please try again.', 'ecab-taxi-booking-manager');
+                wp_send_json_error(['message' => $message]);
+            }
+
+            wp_send_json_success([
+                'message'      => __('Transportation saved successfully.', 'ecab-taxi-booking-manager'),
+                'post_id'      => (int) $post_id,
+                'title'        => get_the_title($post_id),
+                'status'       => get_post_status($post_id),
+                'status_slug'  => 'publish',
+                'status_label' => __('Published', 'ecab-taxi-booking-manager'),
+            ]);
         }
 
         // 4. Redirect default WP editor → custom page

--- a/Admin/MPTBM_Transportation.php
+++ b/Admin/MPTBM_Transportation.php
@@ -12,6 +12,7 @@ class MPTBM_Transportation
         add_action('admin_post_mptbm_trash_transport', array($this, 'mptbm_trash_transport_callback'));
         add_action('admin_post_mptbm_restore_transport', array($this, 'mptbm_restore_transport_callback'));
         add_action('admin_post_mptbm_delete_transport', array($this, 'mptbm_delete_transport_callback'));
+        add_action('admin_post_mptbm_duplicate_transport', array($this, 'mptbm_duplicate_transport_callback'));
     }
 
     public function reorder_mptbm_submenu()
@@ -91,6 +92,118 @@ class MPTBM_Transportation
         exit;
     }
 
+    /**
+     * Duplicate a transportation vehicle as a fresh draft, cloning every meta
+     * field, the featured image, gallery and taxonomy terms, and minting a new
+     * linked hidden WooCommerce product (never sharing the source's product).
+     */
+    public function mptbm_duplicate_transport_callback()
+    {
+        $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+        if (!$id || !isset($_GET['_wpnonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['_wpnonce'])), 'mptbm_duplicate_' . $id)) {
+            wp_die('Invalid request');
+        }
+        if (!current_user_can('edit_post', $id) || !current_user_can('edit_posts')) {
+            wp_die('You are not allowed to duplicate this item.');
+        }
+
+        $new_id = $this->duplicate_transport($id);
+        if (is_wp_error($new_id) || !$new_id) {
+            wp_safe_redirect(add_query_arg('mptbm_message', 'duplicate_failed', $this->base_url()));
+            exit;
+        }
+
+        wp_safe_redirect(add_query_arg(
+            array('mptbm_message' => 'duplicated', 'mptbm_new' => $new_id),
+            $this->base_url()
+        ));
+        exit;
+    }
+
+    /**
+     * Deep-clones a mptbm_rent post. Returns the new post ID or a WP_Error.
+     * Copies all meta except internal/link keys, re-attaches taxonomy terms,
+     * and rebuilds the hidden WooCommerce product link from scratch.
+     */
+    private function duplicate_transport($source_id)
+    {
+        $source = get_post($source_id);
+        if (!$source || $source->post_type !== 'mptbm_rent' || $source->post_status === 'trash') {
+            return new WP_Error('mptbm_invalid_source', __('Source transportation not found.', 'ecab-taxi-booking-manager'));
+        }
+
+        /* translators: %s: original vehicle title. */
+        $new_title = sprintf(__('%s (Copy)', 'ecab-taxi-booking-manager'), $source->post_title);
+
+        $new_id = wp_insert_post(array(
+            'post_title'   => $new_title,
+            'post_content' => $source->post_content,
+            'post_excerpt' => $source->post_excerpt,
+            'post_status'  => 'draft',
+            'post_type'    => 'mptbm_rent',
+            'post_author'  => get_current_user_id(),
+            'menu_order'   => $source->menu_order,
+            'comment_status' => $source->comment_status,
+            'ping_status'  => $source->ping_status,
+        ), true);
+
+        if (is_wp_error($new_id) || !$new_id) {
+            return $new_id ?: new WP_Error('mptbm_insert_failed', __('Could not create the duplicate.', 'ecab-taxi-booking-manager'));
+        }
+
+        // Re-attach every taxonomy term (locations, etc.).
+        foreach (get_object_taxonomies('mptbm_rent') as $taxonomy) {
+            $terms = wp_get_object_terms($source_id, $taxonomy, array('fields' => 'ids'));
+            if (!is_wp_error($terms) && !empty($terms)) {
+                wp_set_object_terms($new_id, array_map('intval', $terms), $taxonomy);
+            }
+        }
+
+        // Copy all post meta except internal editor locks and the WC product
+        // link (which must be unique per vehicle and is rebuilt below).
+        $excluded = array(
+            'link_wc_product',   // rebuilt fresh so two vehicles never share one product
+            'link_mptbm_id',     // lives on the product side only
+            'check_if_run_once', // lets the hidden-product hook run for the copy
+            '_edit_lock',
+            '_edit_last',
+            '_wp_old_slug',
+            '_wp_old_date',
+        );
+        $all_meta = get_post_meta($source_id);
+        foreach ($all_meta as $key => $values) {
+            if (in_array($key, $excluded, true)) {
+                continue;
+            }
+            foreach ($values as $value) {
+                add_post_meta($new_id, $key, maybe_unserialize($value));
+            }
+        }
+
+        // Rebuild the hidden WooCommerce product link only when WC is active.
+        // In standalone mode there is no mirror product to create; the link
+        // will self-heal later via MPTBM_Hidden_Product::get_or_create_wc_product().
+        $wc_active = class_exists('MPTBM_Function') && MPTBM_Function::is_wc_active();
+        if ($wc_active && class_exists('MPTBM_Hidden_Product')) {
+            MPTBM_Hidden_Product::create_hidden_wc_product($new_id, $new_title);
+            $new_product_id = absint(get_post_meta($new_id, 'link_wc_product', true));
+            if ($new_product_id) {
+                $thumb_id = get_post_thumbnail_id($new_id);
+                if ($thumb_id) {
+                    set_post_thumbnail($new_product_id, $thumb_id);
+                }
+                $tax_status = get_post_meta($new_id, '_tax_status', true) ?: 'none';
+                $tax_class  = get_post_meta($new_id, '_tax_class', true) ?: '';
+                update_post_meta($new_product_id, '_tax_status', $tax_status);
+                update_post_meta($new_product_id, '_tax_class', $tax_class);
+                update_post_meta($new_product_id, '_stock_status', 'instock');
+                update_post_meta($new_product_id, '_manage_stock', 'no');
+            }
+        }
+
+        return $new_id;
+    }
+
     /* ---- Data --------------------------------------------------------- */
     private function get_items($statuses = array('publish', 'draft', 'pending', 'private'))
     {
@@ -139,6 +252,7 @@ class MPTBM_Transportation
                 'trash_link'  => wp_nonce_url(admin_url('admin-post.php?action=mptbm_trash_transport&id=' . $pid), 'mptbm_trash_' . $pid),
                 'restore_link' => wp_nonce_url(admin_url('admin-post.php?action=mptbm_restore_transport&id=' . $pid), 'mptbm_restore_' . $pid),
                 'delete_link'  => wp_nonce_url(admin_url('admin-post.php?action=mptbm_delete_transport&id=' . $pid), 'mptbm_delete_' . $pid),
+                'duplicate_link' => wp_nonce_url(admin_url('admin-post.php?action=mptbm_duplicate_transport&id=' . $pid), 'mptbm_duplicate_' . $pid),
             );
         }
 
@@ -270,6 +384,28 @@ class MPTBM_Transportation
         <div class="wrap mptbm-fleet-wrap">
             <div class="mptbm-fleet mptbm-view-list">
 
+                <?php
+                // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                $mptbm_msg = isset($_GET['mptbm_message']) ? sanitize_key(wp_unslash($_GET['mptbm_message'])) : '';
+                if ($mptbm_msg === 'duplicated') :
+                    // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                    $new_id    = isset($_GET['mptbm_new']) ? intval($_GET['mptbm_new']) : 0;
+                    $edit_copy = ($new_id && get_post_type($new_id) === 'mptbm_rent') ? admin_url('admin.php?page=mptbm-rent-edit&post_id=' . $new_id) : '';
+                    ?>
+                    <div class="mptbm-notice success">
+                        <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"/></svg>
+                        <span><?php esc_html_e('Transportation duplicated as a draft.', 'ecab-taxi-booking-manager'); ?></span>
+                        <?php if ($edit_copy) : ?>
+                            <a href="<?php echo esc_url($edit_copy); ?>"><?php esc_html_e('Edit the copy', 'ecab-taxi-booking-manager'); ?> &rarr;</a>
+                        <?php endif; ?>
+                    </div>
+                <?php elseif ($mptbm_msg === 'duplicate_failed') : ?>
+                    <div class="mptbm-notice error">
+                        <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                        <span><?php esc_html_e('Could not duplicate this transportation. Please try again.', 'ecab-taxi-booking-manager'); ?></span>
+                    </div>
+                <?php endif; ?>
+
                 <div class="mptbm-page-header">
                     <div class="mptbm-page-title"><?php esc_html_e('Transportation', 'ecab-taxi-booking-manager'); ?>
                         <span><?php echo esc_html(sprintf(_n('%d vehicle', '%d vehicles', $total, 'ecab-taxi-booking-manager'), $total)); ?></span>
@@ -394,6 +530,9 @@ class MPTBM_Transportation
                                         <a class="mptbm-act-btn edit" href="<?php echo esc_url($it['edit_link']); ?>" title="<?php esc_attr_e('Edit', 'ecab-taxi-booking-manager'); ?>">
                                             <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
                                         </a>
+                                        <a class="mptbm-act-btn dup" href="<?php echo esc_url($it['duplicate_link']); ?>" title="<?php esc_attr_e('Duplicate', 'ecab-taxi-booking-manager'); ?>" onclick="return confirm('<?php echo esc_js(__('Create a duplicate of this transportation?', 'ecab-taxi-booking-manager')); ?>');">
+                                            <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+                                        </a>
                                         <a class="mptbm-act-btn del" href="<?php echo esc_url($it['trash_link']); ?>" title="<?php esc_attr_e('Move to Trash', 'ecab-taxi-booking-manager'); ?>" onclick="return confirm('<?php echo esc_js(__('Move this item to Trash?', 'ecab-taxi-booking-manager')); ?>');">
                                             <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
                                         </a>
@@ -492,6 +631,7 @@ class MPTBM_Transportation
                                         <a class="mptbm-table-del" href="<?php echo esc_url($it['delete_link']); ?>" onclick="return confirm('<?php echo esc_js(__('Permanently delete this item? This cannot be undone.', 'ecab-taxi-booking-manager')); ?>');"><?php esc_html_e('Delete', 'ecab-taxi-booking-manager'); ?></a>
                                     <?php else : ?>
                                         <a class="mptbm-table-edit" href="<?php echo esc_url($it['edit_link']); ?>"><?php esc_html_e('Edit', 'ecab-taxi-booking-manager'); ?></a>
+                                        <a class="mptbm-table-dup" href="<?php echo esc_url($it['duplicate_link']); ?>" onclick="return confirm('<?php echo esc_js(__('Create a duplicate of this transportation?', 'ecab-taxi-booking-manager')); ?>');"><?php esc_html_e('Duplicate', 'ecab-taxi-booking-manager'); ?></a>
                                         <a class="mptbm-table-del" href="<?php echo esc_url($it['trash_link']); ?>" onclick="return confirm('<?php echo esc_js(__('Move this item to Trash?', 'ecab-taxi-booking-manager')); ?>');"><?php esc_html_e('Trash', 'ecab-taxi-booking-manager'); ?></a>
                                     <?php endif; ?>
                                 </td>

--- a/Admin/settings/MPTBM_Payment_Settings.php
+++ b/Admin/settings/MPTBM_Payment_Settings.php
@@ -363,9 +363,11 @@
 				.mptbm-bm-status{min-height:16px;margin:6px 2px 0;font-size:12px;font-weight:600;}
 				.mptbm-bm-gateway-warning{display:flex;align-items:flex-start;gap:8px;margin-top:10px;padding:9px 12px;border-radius:8px;background:#fff7ed;border:1px solid #fed7aa;color:#9a3412;font-size:12px;}
 				.mptbm-bm-gateway-warning p{margin:0;}
-				.mptbm-bm-auto-note{display:flex;align-items:flex-start;gap:10px;background:#eff6ff;border:1px solid #bfdbfe;color:#1e3a8a;border-radius:10px;padding:10px 14px;margin:4px 0 12px;font-size:12px;}
-				.mptbm-bm-auto-note--warn{background:#fef2f2;border-color:#fecaca;color:#991b1b;}
-				.mptbm-bm-auto-note p{margin:0;}
+				.mptbm-bm-auto-note{display:flex;align-items:center;gap:12px;background:#f0fdf4;border:1px solid #bbf7d0;color:#14532d;border-radius:12px;padding:14px 16px;margin:6px 0 14px;font-size:13px;line-height:1.55;box-shadow:0 1px 2px rgba(16,24,40,0.03);}
+				.mptbm-bm-auto-note .dashicons{flex:0 0 auto;width:32px;height:32px;display:inline-flex;align-items:center;justify-content:center;font-size:18px;border-radius:9px;background:#dcfce7;color:#16a34a;}
+				.mptbm-bm-auto-note p{margin:0;font-weight:500;}
+				.mptbm-bm-auto-note--warn{background:#fff5f5;border-color:#fbcfcf;color:#8a1c1c;}
+				.mptbm-bm-auto-note--warn .dashicons{background:#fee2e2;color:#dc2626;}
 				.mptbm-pay-subtab-badge{margin-left:6px;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.4px;background:rgba(255,255,255,0.9);color:#166534;padding:1px 7px;border-radius:20px;vertical-align:middle;}
 				@media (max-width:680px){.mptbm-bm-cards{grid-template-columns:1fr;}}
 				</style>
@@ -398,16 +400,18 @@
 					</h2>
 					<?php if ( ! $wc_active ) : ?>
 						<div class="woocommerce-field">
-							<div class="mptbm-woo-warning-notice" style="background:#fff3cd;color:#856404;padding:15px;border-left:4px solid #ffeeba;border-radius:6px;margin:15px 0 10px;">
-								<div style="display:flex;flex-direction:column;align-items:flex-start;gap:15px;">
-									<div style="width:100%;">
-										<strong style="display:block;font-size:14px;margin-bottom:5px;"><i class="fas fa-exclamation-triangle" style="margin-right:5px;"></i><?php esc_html_e( 'Notice: WooCommerce is Not Activated', 'ecab-taxi-booking-manager' ); ?></strong>
-										<span style="font-size:13px;display:block;"><?php esc_html_e( 'To process bookings through the WooCommerce cart/checkout flow, you must install and activate WooCommerce. Otherwise, use the Custom Payment tab.', 'ecab-taxi-booking-manager' ); ?></span>
-									</div>
-									<div>
-										<button type="button" class="button button-primary mptbm-install-wc-trigger" style="white-space:nowrap;"><?php echo wp_kses_post( $btn_text ); ?></button>
-									</div>
+							<div class="mptbm-wc-callout">
+								<div class="mptbm-wc-callout-head">
+									<span class="mptbm-wc-callout-icon" aria-hidden="true">
+										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+									</span>
+									<h4 class="mptbm-wc-callout-title"><?php esc_html_e( 'WooCommerce is not activated', 'ecab-taxi-booking-manager' ); ?></h4>
 								</div>
+								<p class="mptbm-wc-callout-text"><?php esc_html_e( 'To take bookings through the WooCommerce cart & checkout flow, install and activate WooCommerce. Prefer not to use it? Switch to the Custom Payment tab.', 'ecab-taxi-booking-manager' ); ?></p>
+								<button type="button" class="mptbm-install-wc-trigger mptbm-wc-callout-btn">
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v11"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
+									<?php echo wp_kses_post( $btn_text ); ?>
+								</button>
 							</div>
 						</div>
 					<?php endif; ?>
@@ -935,42 +939,61 @@
 				.payment-sub-tabs .nav-tab:hover{background:#fbeaf1;color:var(--mptbm-pay-accent) !important;}
 				.payment-sub-tabs .nav-tab-active,.payment-sub-tabs .nav-tab-active:hover{background:var(--mptbm-pay-accent);color:#fff !important;box-shadow:0 4px 12px rgba(241,41,113,0.28);}
 
+				/* WooCommerce-not-activated callout (modern) */
+				.mptbm-wc-callout{background:linear-gradient(180deg,#fffdf6,#fff8e8);border:1px solid #f2e0b0;border-radius:14px;padding:18px;margin:16px 0 6px;box-shadow:0 1px 2px rgba(16,24,40,0.03);}
+				.mptbm-wc-callout .mptbm-wc-callout-head{display:flex !important;align-items:center;gap:12px;margin-bottom:9px;}
+				.mptbm-wc-callout .mptbm-wc-callout-icon{flex:0 0 auto;width:40px;height:40px;border-radius:11px;background:#fff2cf;color:#c07d16;border:1px solid #f2d484;display:flex !important;align-items:center;justify-content:center;}
+				.mptbm-wc-callout .mptbm-wc-callout-icon svg{width:21px;height:21px;display:block;}
+				.mptbm-wc-callout .mptbm-wc-callout-title{margin:0;padding:0;font-size:15px;font-weight:700;color:#1d2327;line-height:1.3;text-transform:none;}
+				.mptbm-wc-callout-text{margin:0 0 15px;font-size:13px;color:#6b7280;line-height:1.55;max-width:720px;}
+				.mptbm-wc-callout-btn{display:inline-flex;align-items:center;gap:8px;height:38px;padding:0 18px;border:none;border-radius:9px;background:#7f54b3;color:#fff !important;font-size:13.5px;font-weight:600;cursor:pointer;line-height:1;box-shadow:0 2px 6px rgba(127,84,179,0.3);transition:all .18s ease;text-decoration:none;}
+				.mptbm-wc-callout-btn:hover{background:#6b4599;transform:translateY(-1px);box-shadow:0 5px 14px rgba(127,84,179,0.34);color:#fff !important;}
+				.mptbm-wc-callout-btn:active{transform:translateY(0);}
+				.mptbm-wc-callout-btn svg{width:16px;height:16px;display:block;}
+
 				/* Custom Payment intro */
 				.mptbm-gw-intro{margin:4px 0 20px;}
 				.mptbm-gw-intro h3{margin:0 0 6px;font-size:16px;font-weight:700;color:#1d2327;}
 				.mptbm-gw-intro p{margin:0;font-size:13px;color:#6b7280;max-width:680px;line-height:1.6;}
 
-				/* Gateway cards (Custom Payment) */
+				/* Gateway cards (Custom Payment) - light, modern palette */
 				.payment-gateways-container th{display:none;}
 				.payment-gateways-container td{padding:0 !important;}
-				.gateway-card{border:none;border-radius:14px;margin-bottom:16px;box-shadow:0 6px 18px rgba(16,24,40,0.10);width:100%;box-sizing:border-box;color:#fff;overflow:hidden;transition:transform 0.18s ease,box-shadow 0.18s ease;}
-				.gateway-card:hover{transform:translateY(-2px);box-shadow:0 12px 28px rgba(16,24,40,0.16);}
-				.gateway-card .gateway-header{display:flex;justify-content:space-between;align-items:center;gap:16px;padding:18px 22px;}
+				.gateway-card{position:relative;background:#fff;border:1px solid #eceef2;border-left:4px solid #cbd5e1;border-radius:14px;margin-bottom:13px;box-shadow:0 1px 2px rgba(16,24,40,0.04);width:100%;box-sizing:border-box;color:#1d2327;overflow:hidden;transition:transform 0.18s ease,box-shadow 0.18s ease,border-color 0.18s ease;}
+				.gateway-card:hover{transform:translateY(-2px);box-shadow:0 10px 24px rgba(16,24,40,0.10);}
+				.gateway-card .gateway-header{display:flex;justify-content:space-between;align-items:center;gap:16px;padding:16px 20px;}
 				.gateway-card .gateway-id{display:flex;align-items:center;gap:14px;min-width:0;flex:1 1 0;}
-				.gateway-card .gateway-icon{flex:0 0 auto;width:46px;height:46px;border-radius:12px;background:rgba(255,255,255,0.16);display:flex;align-items:center;justify-content:center;}
+				.gateway-card .gateway-icon{flex:0 0 auto;width:44px;height:44px;border-radius:12px;display:flex;align-items:center;justify-content:center;color:#fff;box-shadow:0 4px 10px rgba(16,24,40,0.13);}
 				.gateway-card .gateway-meta{display:flex;flex-direction:column;min-width:0;}
-				.gateway-card .gateway-name{font-size:16px;font-weight:700;color:#fff;line-height:1.3;}
-				.gateway-card .gateway-sub{font-size:12px;color:rgba(255,255,255,0.82);line-height:1.4;}
+				.gateway-card .gateway-name{font-size:15.5px;font-weight:700;color:#1d2327;line-height:1.3;}
+				.gateway-card .gateway-sub{font-size:12px;color:#6b7280;line-height:1.4;}
 				.gateway-card .gateway-actions{display:flex;align-items:center;justify-content:flex-end;gap:12px;flex:1 1 0;}
-				.gateway-card .gateway-status{display:inline-block;min-width:78px;text-align:center;font-size:11px;text-transform:uppercase;letter-spacing:0.4px;padding:4px 11px;border-radius:20px;background:rgba(255,255,255,0.2);color:#fff;font-weight:700;}
-				.gateway-card .gateway-status.active{background:#fff;}
-				.gateway-card.paypal-card{background:linear-gradient(135deg,#003087 0%,#0079C1 100%);}
-				.gateway-card.paypal-card .gateway-status.active{color:#003087;}
-				.gateway-card.stripe-card{background:linear-gradient(135deg,#635bff 0%,#3f36c5 100%);}
-				.gateway-card.stripe-card .gateway-status.active{color:#635bff;}
-				.gateway-card.offline-card{background:linear-gradient(135deg,#0f766e 0%,#115e59 100%);}
-				.gateway-card.offline-card .gateway-status.active{color:#0f766e;}
-				.gateway-card .gateway-configure-btn{cursor:pointer;color:#1d2327 !important;background:#fff !important;border:none !important;font-weight:600 !important;font-size:13px !important;border-radius:8px !important;padding:7px 16px !important;line-height:1.4 !important;box-shadow:0 2px 6px rgba(0,0,0,0.18) !important;transition:opacity 0.15s ease;}
-				.gateway-card .gateway-configure-btn:hover{opacity:0.9;}
-				.mptbm-gw-pro-badge{background:linear-gradient(135deg,#f6d365 0%,#fda085 100%);color:#fff;padding:5px 12px;border-radius:20px;font-weight:bold;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;box-shadow:0 2px 6px rgba(253,160,133,0.4);}
+				.gateway-card .gateway-status{display:inline-block;min-width:74px;text-align:center;font-size:10.5px;text-transform:uppercase;letter-spacing:0.4px;padding:4px 11px;border-radius:20px;background:#f1f5f9;color:#64748b;border:1px solid #e5e9f0;font-weight:700;}
+				.gateway-card .gateway-status.active{background:#dcfce7;color:#15803d;border-color:#bbf7d0;}
+				/* Per-brand: soft tinted card + accent stripe + vibrant icon badge */
+				.gateway-card.paypal-card{background:#f4f9fe;border-left-color:#0070ba;}
+				.gateway-card.paypal-card .gateway-icon{background:linear-gradient(135deg,#0079C1,#003087);}
+				.gateway-card.stripe-card{background:#f6f5ff;border-left-color:#635bff;}
+				.gateway-card.stripe-card .gateway-icon{background:linear-gradient(135deg,#7a73ff,#4f46e5);}
+				.gateway-card.offline-card{background:#f0faf8;border-left-color:#14b8a6;}
+				.gateway-card.offline-card .gateway-icon{background:linear-gradient(135deg,#14b8a6,#0f766e);}
+				.gateway-card .gateway-configure-btn{cursor:pointer;color:#fff !important;border:none !important;font-weight:600 !important;font-size:13px !important;border-radius:8px !important;padding:7px 16px !important;line-height:1.4 !important;box-shadow:0 2px 6px rgba(16,24,40,0.14) !important;transition:transform 0.15s ease,opacity 0.15s ease;}
+				.gateway-card.paypal-card .gateway-configure-btn{background:#0070ba !important;}
+				.gateway-card.stripe-card .gateway-configure-btn{background:#635bff !important;}
+				.gateway-card.offline-card .gateway-configure-btn{background:#0f766e !important;}
+				.gateway-card .gateway-configure-btn:hover{transform:translateY(-1px);opacity:0.94;}
+				.mptbm-gw-pro-badge{background:linear-gradient(135deg,#fbbf24,#f59e0b);color:#fff;padding:5px 12px;border-radius:20px;font-weight:800;font-size:10.5px;text-transform:uppercase;letter-spacing:0.5px;box-shadow:0 2px 6px rgba(245,158,11,0.3);}
 
 				/* Booking confirmation page */
-				.mptbm-conf-page{margin-top:10px;padding:22px 24px;display:flex;align-items:center;gap:24px;flex-wrap:wrap;background:#fafafb;border:1px solid #ececf0;border-radius:14px;}
+				.mptbm-conf-page{margin-top:10px;padding:20px 22px;display:flex;align-items:center;gap:24px;flex-wrap:wrap;background:#fff;border:1px solid #eceef2;border-radius:14px;box-shadow:0 1px 2px rgba(16,24,40,0.04);transition:border-color 0.18s ease,box-shadow 0.18s ease;}
+				.mptbm-conf-page:hover{border-color:#dcdfe6;box-shadow:0 4px 14px rgba(16,24,40,0.06);}
 				.mptbm-conf-page-label{flex:1 1 260px;}
 				.mptbm-conf-page-label label{display:block;font-weight:700;font-size:14px;color:#1d2327;margin:0 0 4px;}
 				.mptbm-conf-page-label span{display:block;font-size:12px;color:#6b7280;line-height:1.6;}
 				.mptbm-conf-page-field{flex:0 0 auto;}
-				.mptbm-conf-page-field select{width:100%;max-width:320px;border:1px solid #d1d5db;border-radius:8px;padding:7px 12px;font-size:13px;background:#fff;}
+				.mptbm-conf-page-field select{width:100%;max-width:320px;min-width:230px;border:1px solid #d1d5db;border-radius:9px;padding:9px 13px;font-size:13px;font-weight:500;color:#334155;background:#fff;transition:border-color 0.18s ease,box-shadow 0.18s ease;}
+				.mptbm-conf-page-field select:hover{border-color:#9aa4b2;}
+				.mptbm-conf-page-field select:focus{border-color:var(--mptbm-pay-accent);box-shadow:0 0 0 3px rgba(241,41,113,0.16);outline:none;}
 
 				/* WooCommerce sub-tab accordions */
 				tr.mptbm-acc-header > td.mptbm-acc-header-cell{padding:0 !important;}
@@ -992,6 +1015,21 @@
 				</style>
 				<script>
 				jQuery(function($){
+					// Deep-link from the "Go to Payment Settings" admin notice: open the
+					// Payments tab (and, when WooCommerce is inactive, nudge the WC card
+					// into view) instead of landing on the default first tab.
+					(function(){
+						var params = new URLSearchParams(window.location.search || '');
+						if (params.get('mptbm_tab') !== 'payments') { return; }
+						var $target = $('[data-tabs-target="#<?php echo esc_js( self::OPTION ); ?>"]');
+						if (!$target.length) { return; }
+						setTimeout(function(){
+							$target.trigger('click');
+							var el = $target.get(0);
+							if (el && el.scrollIntoView) { el.scrollIntoView({ behavior: 'smooth', block: 'center' }); }
+						}, 200);
+					})();
+
 					var wcActive = <?php echo $wc_active; ?>;
 					if ($('.payment-sub-tabs').length === 0) { return; }
 

--- a/Admin/settings/MPTBM_Right_Side_Content_Settings.php
+++ b/Admin/settings/MPTBM_Right_Side_Content_Settings.php
@@ -53,39 +53,49 @@ if ( ! class_exists('MPTBM_Right_Side_Content_Settings') ) {
                        value="<?php echo esc_attr($post_id); ?>">
 
                 <div class="mptbm_taxi_category_card">
-                    <div class="" style="display: flex; justify-content: space-between">
-                        <label class="mptbm_taxi_category_label"> <?php esc_html_e( 'Categories', 'ecab-taxi-booking-manager' ); ?></label>
-                        <label class="mptbm_taxi_all_category_label"> <?php esc_html_e( 'All Categories', 'ecab-taxi-booking-manager' ); ?></label>
-
+                    <div class="mptbm_taxi_card_head">
+                        <span class="mptbm_taxi_card_icon" aria-hidden="true">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
+                        </span>
+                        <div class="mptbm_taxi_card_head_text">
+                            <label class="mptbm_taxi_category_label"><?php esc_html_e( 'Categories', 'ecab-taxi-booking-manager' ); ?></label>
+                            <span class="mptbm_taxi_category_subtext"><?php esc_html_e( 'Select vehicle category', 'ecab-taxi-booking-manager' ); ?></span>
+                        </div>
+                        <button type="button" class="mptbm_taxi_all_category_label">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+                            <?php esc_html_e( 'All Categories', 'ecab-taxi-booking-manager' ); ?>
+                        </button>
                     </div>
-                    <span class="mptbm_taxi_category_subtext">
-                         <?php esc_html_e( 'Select vehicle category', 'ecab-taxi-booking-manager' ); ?>
-                    </span>
 
                     <div class="mptbm_taxi_category_flex_group" id="mptbm_taxi_category_flex_group">
 
-                        <select id="mptbm_taxi_category_dropdown"
-                                class="mptbm_taxi_category_select">
+                        <div class="mptbm_taxi_select_wrap">
+                            <select id="mptbm_taxi_category_dropdown"
+                                    class="mptbm_taxi_category_select">
 
-                            <option value="" disabled><?php esc_html_e( 'Select Category', 'ecab-taxi-booking-manager' ); ?></option>
+                                <option value="" disabled <?php selected($saved_category, ''); ?>><?php esc_html_e( 'Select Category', 'ecab-taxi-booking-manager' ); ?></option>
 
-                            <?php foreach ($categories as $cat) : ?>
+                                <?php foreach ($categories as $cat) : ?>
 
-                                <option value="<?php echo esc_attr($cat['id']); ?>"
-                                    <?php selected($saved_category, $cat['id']); ?>>
+                                    <option value="<?php echo esc_attr($cat['id']); ?>"
+                                        <?php selected($saved_category, $cat['id']); ?>>
 
-                                    <?php echo esc_html($cat['name']); ?>
+                                        <?php echo esc_html($cat['name']); ?>
 
-                                </option>
+                                    </option>
 
-                            <?php endforeach; ?>
+                                <?php endforeach; ?>
 
-                        </select>
+                            </select>
+                            <svg class="mptbm_taxi_select_chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+                        </div>
 
                         <button type="button"
                                 id="mptbm_taxi_category_open_popup"
-                                class="mptbm_taxi_category_btn_add">
-                            +
+                                class="mptbm_taxi_category_btn_add"
+                                title="<?php esc_attr_e( 'Add new category', 'ecab-taxi-booking-manager' ); ?>"
+                                aria-label="<?php esc_attr_e( 'Add new category', 'ecab-taxi-booking-manager' ); ?>">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                         </button>
 
                     </div>
@@ -104,15 +114,21 @@ if ( ! class_exists('MPTBM_Right_Side_Content_Settings') ) {
                 ?>
 
                 <div class="mptbm_taxi_category_card">
-                    <label class="mptbm_taxi_category_label"><?php esc_html_e( 'Tags', 'ecab-taxi-booking-manager' ); ?></label>
-                    <span class="mptbm_taxi_category_subtext">
-                        <?php esc_html_e( 'Add keywords for searching', 'ecab-taxi-booking-manager' ); ?>
-                    </span>
+                    <div class="mptbm_taxi_card_head">
+                        <span class="mptbm_taxi_card_icon" aria-hidden="true">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
+                        </span>
+                        <div class="mptbm_taxi_card_head_text">
+                            <label class="mptbm_taxi_category_label"><?php esc_html_e( 'Tags', 'ecab-taxi-booking-manager' ); ?></label>
+                            <span class="mptbm_taxi_category_subtext"><?php esc_html_e( 'Add keywords for searching', 'ecab-taxi-booking-manager' ); ?></span>
+                        </div>
+                    </div>
                     <div class="mptbm_taxi_category_tag_input_wrapper">
+                        <svg class="mptbm_taxi_tag_input_icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
                         <input type="text"
                                id="mptbm_taxi_category_tag_input"
                                class="mptbm_taxi_category_input"
-                               placeholder="<?php esc_html_e( 'Add a tag and press Enter', 'ecab-taxi-booking-manager' ); ?>">
+                               placeholder="<?php esc_attr_e( 'Add a tag and press Enter', 'ecab-taxi-booking-manager' ); ?>">
                     </div>
                     <div id="mptbm_taxi_category_tags_list"
                          class="mptbm_taxi_category_tags_container">

--- a/assets/admin/mptbm_demo_import.js
+++ b/assets/admin/mptbm_demo_import.js
@@ -1,66 +1,106 @@
 /**
- * MPTBM demo-data importer popup.
+ * MPTBM demo-data importer — bottom-right circular progress widget.
  *
- * Uses delegated event binding (on `document`) so the handlers work no matter
- * when the popup markup appears or whether the page re-renders its DOM, and is
- * loaded as an enqueued script with a jQuery dependency. Nonces/strings come in
- * via wp_localize_script as `mptbm_demo_import`.
+ * On a fresh install with no transports yet, the widget auto-starts the demo
+ * import and shows a modern radial progress ring. No blocking modal and no
+ * confirmation step. Nonces/strings arrive via wp_localize_script as
+ * `mptbm_demo_import`. Delegated handlers keep retry/close working regardless
+ * of when the markup lands in the DOM.
  */
 (function ($) {
 	'use strict';
 
-	var config  = window.mptbm_demo_import || {};
-	var working = false;
+	var config   = window.mptbm_demo_import || {};
+	var i18n     = config.i18n || {};
+	var working  = false;
+	var creep    = null;
+	var progress = 0;
 
-	// Helps confirm in the console that this file actually loaded/ran.
-	if (window.console && console.log) {
-		console.log('[MPTBM] demo-import script loaded');
+	function byId(id) {
+		return document.getElementById(id);
 	}
 
-	function showError($overlay, message) {
-		var $popup    = $overlay.find('.mptbm-inst-popup');
-		var $progress = $('#mptbm-demo-progress');
-		var $fill     = $('#mptbm-demo-progress-fill');
-		var $status   = $('#mptbm-demo-status-text');
-		var $actions  = $overlay.find('.mptbm-inst-actions');
+	// Circumference of the progress arc, derived from its actual radius so the
+	// dash math stays correct even if the SVG geometry is tweaked later.
+	function ringCircumference() {
+		var arc = byId('mptbm-dw-arc');
+		var r   = arc ? (parseFloat(arc.getAttribute('r')) || 34) : 34;
+		return 2 * Math.PI * r;
+	}
 
+	function setProgress(p) {
+		p = Math.max(0, Math.min(1, p));
+		progress = p;
+		var arc = byId('mptbm-dw-arc');
+		var pct = byId('mptbm-dw-pct');
+		var c   = ringCircumference();
+		if (arc) { arc.style.strokeDashoffset = String(c * (1 - p)); }
+		if (pct) { pct.textContent = Math.round(p * 100) + '%'; }
+	}
+
+	function setStatus(text) {
+		var el = byId('mptbm-dw-status');
+		if (el && text) { el.textContent = text; }
+	}
+
+	// Decelerating creep toward 90% while the request is in flight — the import
+	// is a single server round-trip, so we simulate smooth forward motion and
+	// snap to 100% only once it truly completes.
+	function startCreep() {
+		stopCreep();
+		creep = window.setInterval(function () {
+			if (progress < 0.9) {
+				setProgress(progress + (0.9 - progress) * 0.06);
+			}
+			if (progress > 0.35 && progress < 0.75) {
+				setStatus(i18n.importing);
+			} else if (progress >= 0.75) {
+				setStatus(i18n.finishing);
+			}
+		}, 200);
+	}
+
+	function stopCreep() {
+		if (creep) { window.clearInterval(creep); creep = null; }
+	}
+
+	function showSuccess() {
+		stopCreep();
+		var widget = byId('mptbm-demo-widget');
+		var title  = byId('mptbm-dw-title');
+		if (widget) { widget.classList.remove('is-error'); widget.classList.add('is-success'); }
+		setProgress(1);
+		if (title) { title.textContent = i18n.success_title || 'All set!'; }
+		setStatus(i18n.success);
+		window.setTimeout(function () { window.location.reload(); }, 1400);
+	}
+
+	function showError() {
 		working = false;
-		$popup.addClass('mptbm-state-error');
-		$status.text(message).addClass('mptbm-error');
-		$fill.css('width', '100%');
-		$('#mptbm-demo-import-btn, #mptbm-demo-dismiss-btn').prop('disabled', false);
-		$actions.slideDown(250);
-		setTimeout(function () {
-			$popup.removeClass('mptbm-state-error');
-			$progress.slideUp(250);
-			$fill.css('width', '0%');
-		}, 3500);
+		stopCreep();
+		var widget = byId('mptbm-demo-widget');
+		var title  = byId('mptbm-dw-title');
+		var retry  = byId('mptbm-dw-retry');
+		var close  = byId('mptbm-dw-close');
+		if (widget) { widget.classList.remove('is-success'); widget.classList.add('is-error'); }
+		if (title) { title.textContent = i18n.error_title || 'Import failed'; }
+		setStatus(i18n.error);
+		if (retry) { retry.style.display = 'inline-flex'; }
+		if (close) { close.style.display = 'flex'; }
 	}
 
-	// Open from anywhere via a trigger element.
-	$(document).on('click', '#mptbm-trigger-demo-import', function (e) {
-		e.preventDefault();
-		$('#mptbm-demo-overlay').css('display', 'flex');
-	});
-
-	// Import.
-	$(document).on('click', '#mptbm-demo-import-btn', function (e) {
-		e.preventDefault();
+	function runImport() {
 		if (working) { return; }
 		working = true;
 
-		var $overlay  = $('#mptbm-demo-overlay');
-		var $popup    = $overlay.find('.mptbm-inst-popup');
-		var $progress = $('#mptbm-demo-progress');
-		var $fill     = $('#mptbm-demo-progress-fill');
-		var $status   = $('#mptbm-demo-status-text');
-		var $actions  = $overlay.find('.mptbm-inst-actions');
+		var widget = byId('mptbm-demo-widget');
+		var retry  = byId('mptbm-dw-retry');
+		if (widget) { widget.classList.remove('is-error', 'is-success'); }
+		if (retry) { retry.style.display = 'none'; }
 
-		$('#mptbm-demo-import-btn, #mptbm-demo-dismiss-btn').prop('disabled', true);
-		$actions.slideUp(250);
-		$progress.slideDown(300);
-		$fill.css('width', '55%');
-		$status.text((config.i18n && config.i18n.importing) || 'Importing...').removeClass('mptbm-success mptbm-error');
+		setProgress(0.08);
+		setStatus(i18n.preparing);
+		startCreep();
 
 		$.ajax({
 			url: (config.ajax_url || window.ajaxurl),
@@ -72,40 +112,45 @@
 			}
 		}).done(function (response) {
 			if (response && response.success) {
-				$fill.css('width', '100%');
-				$popup.addClass('mptbm-state-success');
-				$status.text((config.i18n && config.i18n.success) || 'Done!').addClass('mptbm-success');
-				$popup.find('.mptbm-inst-icon').html('<svg width="40" height="40" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/><path d="M8 12l3 3 5-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>');
-				$popup.find('.mptbm-inst-title').text((config.i18n && config.i18n.success_title) || 'All set!');
-				setTimeout(function () { window.location.reload(); }, 1500);
+				showSuccess();
 			} else {
-				showError($overlay, (response && response.data && response.data.message) ? response.data.message : ((config.i18n && config.i18n.error) || 'Import failed.'));
+				showError();
 			}
 		}).fail(function (xhr) {
 			if (window.console && console.error) {
-				console.error('[MPTBM] demo import AJAX failed', xhr && xhr.status, xhr && xhr.responseText);
+				console.error('[MPTBM] demo import failed', xhr && xhr.status, xhr && xhr.responseText);
 			}
-			showError($overlay, (config.i18n && config.i18n.error) || 'Import failed.');
+			showError();
 		});
+	}
+
+	$(function () {
+		var widget = byId('mptbm-demo-widget');
+		if (!widget) { return; }
+
+		// Prime the ring so the stroke animates up from empty rather than
+		// flashing full on first paint.
+		var arc = byId('mptbm-dw-arc');
+		if (arc) {
+			var c = ringCircumference();
+			arc.style.strokeDasharray  = String(c);
+			arc.style.strokeDashoffset = String(c);
+		}
+
+		// Let the slide-in read before the ring starts moving.
+		window.setTimeout(runImport, 650);
 	});
 
-	// Dismiss.
-	$(document).on('click', '#mptbm-demo-dismiss-btn', function (e) {
+	$(document).on('click', '#mptbm-dw-retry', function (e) {
 		e.preventDefault();
-		if (working) { return; }
-		working = true;
-		var $overlay = $('#mptbm-demo-overlay');
-		$overlay.css('opacity', '0.5');
-		$.ajax({
-			url: (config.ajax_url || window.ajaxurl),
-			type: 'POST',
-			data: {
-				action: 'mptbm_dismiss_dummy_import',
-				nonce:  config.dismiss_nonce
-			}
-		}).always(function () {
-			$overlay.fadeOut(300, function () { $(this).remove(); });
-		});
+		runImport();
+	});
+
+	$(document).on('click', '#mptbm-dw-close', function (e) {
+		e.preventDefault();
+		var $w = $('#mptbm-demo-widget');
+		$w.addClass('is-hiding');
+		window.setTimeout(function () { $w.remove(); }, 300);
 	});
 
 })(jQuery);

--- a/assets/admin/mptbm_installer.css
+++ b/assets/admin/mptbm_installer.css
@@ -455,3 +455,212 @@
 		gap: 8px;
 	}
 }
+
+/* ============================================
+   MPTBM Demo Data — floating progress widget
+   Bottom-right radial progress ring used by the
+   auto demo-data importer. Fully self-contained
+   under .mptbm-dw-* so it never touches the
+   shared .mptbm-inst-* installer styles above.
+   ============================================ */
+
+.mptbm-dw {
+	position: fixed;
+	right: 24px;
+	bottom: 24px;
+	z-index: 999999;
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	width: 340px;
+	max-width: calc(100vw - 40px);
+	padding: 16px 18px;
+	background: #fff;
+	border: 1px solid #eceef2;
+	border-radius: 16px;
+	box-shadow: 0 6px 16px rgba(15, 23, 42, 0.10), 0 24px 48px rgba(15, 23, 42, 0.14);
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	animation: mptbmDwIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes mptbmDwIn {
+	from { opacity: 0; transform: translateY(24px) scale(0.96); }
+	to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.mptbm-dw.is-hiding {
+	animation: mptbmDwOut 0.3s ease forwards;
+}
+
+@keyframes mptbmDwOut {
+	to { opacity: 0; transform: translateY(16px) scale(0.96); }
+}
+
+/* ---------- Radial ring ---------- */
+.mptbm-dw-ring {
+	position: relative;
+	flex-shrink: 0;
+	width: 66px;
+	height: 66px;
+}
+
+.mptbm-dw-svg {
+	display: block;
+	transform: rotate(-90deg); /* start the arc at 12 o'clock */
+}
+
+.mptbm-dw-track {
+	fill: none;
+	stroke: #eef1f6;
+	stroke-width: 7;
+}
+
+.mptbm-dw-arc {
+	fill: none;
+	stroke: url(#mptbmDwGrad);
+	stroke-width: 7;
+	stroke-linecap: round;
+	stroke-dasharray: 213.63;   /* 2 * PI * r(34) */
+	stroke-dashoffset: 213.63;
+	transition: stroke-dashoffset 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.mptbm-dw-pct {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 14px;
+	font-weight: 700;
+	color: #1f2a44;
+	letter-spacing: -0.01em;
+}
+
+.mptbm-dw-mark {
+	position: absolute;
+	inset: 0;
+	display: none;
+	align-items: center;
+	justify-content: center;
+	color: #12b76a;
+}
+
+/* ---------- Body ---------- */
+.mptbm-dw-body {
+	flex: 1;
+	min-width: 0;
+}
+
+.mptbm-dw-brand {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	margin-bottom: 3px;
+}
+
+.mptbm-dw-brand-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border-radius: 6px;
+	background: linear-gradient(135deg, #eff4ff 0%, #e0e7ff 100%);
+	color: #1f6feb;
+	flex-shrink: 0;
+}
+
+.mptbm-dw-title {
+	font-size: 13.5px;
+	font-weight: 700;
+	color: #1d2327;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.mptbm-dw-status {
+	margin: 0;
+	font-size: 12.5px;
+	line-height: 1.45;
+	color: #667085;
+}
+
+/* ---------- Retry / close ---------- */
+.mptbm-dw-retry {
+	display: none;
+	align-items: center;
+	margin-top: 8px;
+	padding: 6px 14px;
+	border: none;
+	border-radius: 7px;
+	background: linear-gradient(135deg, #1f6feb 0%, #4f46e5 100%);
+	color: #fff;
+	font-size: 12px;
+	font-weight: 600;
+	cursor: pointer;
+	box-shadow: 0 2px 8px rgba(31, 111, 235, 0.25);
+	transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.mptbm-dw-retry:hover {
+	transform: translateY(-1px);
+	box-shadow: 0 4px 12px rgba(31, 111, 235, 0.3);
+	color: #fff;
+}
+
+.mptbm-dw-close {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	display: none; /* revealed only on the error state */
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	padding: 0;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	color: #98a2b3;
+	cursor: pointer;
+	transition: background 0.15s ease, color 0.15s ease;
+}
+
+.mptbm-dw-close:hover {
+	background: #f2f4f7;
+	color: #475467;
+}
+
+/* ---------- Success state ---------- */
+.mptbm-dw.is-success .mptbm-dw-arc { stroke: #12b76a; }
+.mptbm-dw.is-success .mptbm-dw-track { stroke: #d1fadf; }
+.mptbm-dw.is-success .mptbm-dw-pct { display: none; }
+.mptbm-dw.is-success .mptbm-dw-title { color: #039855; }
+.mptbm-dw.is-success .mptbm-dw-mark {
+	display: flex;
+	animation: mptbmDwPop 0.45s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes mptbmDwPop {
+	0%   { transform: scale(0.4); opacity: 0; }
+	60%  { transform: scale(1.12); opacity: 1; }
+	100% { transform: scale(1); }
+}
+
+/* ---------- Error state ---------- */
+.mptbm-dw.is-error .mptbm-dw-arc { stroke: #f04438; }
+.mptbm-dw.is-error .mptbm-dw-track { stroke: #fee4e2; }
+.mptbm-dw.is-error .mptbm-dw-pct { color: #d92d20; }
+.mptbm-dw.is-error .mptbm-dw-title { color: #d92d20; }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 600px) {
+	.mptbm-dw {
+		right: 12px;
+		left: 12px;
+		bottom: 12px;
+		width: auto;
+	}
+}

--- a/assets/admin/mptbm_right_side_style.css
+++ b/assets/admin/mptbm_right_side_style.css
@@ -259,14 +259,15 @@
     background: rgba(59,130,246,0.06);
 }
 
-/*Category*/
-/* Container & General Layout */
+/* ==================================
+   CATEGORY & TAGS CARDS (modern)
+================================== */
 .mptbm_taxi_category_container {
     width: 100%;
     background: transparent;
     display: flex;
     flex-direction: column;
-    gap: 20px;
+    gap: 16px;
     box-sizing: border-box;
 }
 
@@ -274,140 +275,237 @@
     background: var(--mp-white);
     border: 1px solid var(--mp-border);
     border-radius: var(--mp-r-lg);
-    padding: 20px;
+    padding: 18px;
     box-shadow: var(--mp-shadow-sm);
     box-sizing: border-box;
+    transition: var(--mp-transition);
+}
+.mptbm_taxi_category_card:hover {
+    border-color: var(--mp-primary-border);
+    box-shadow: var(--mp-shadow-md);
+}
+
+/* Card header: icon + titles + optional action */
+.mptbm_taxi_card_head {
+    display: flex;
+    align-items: flex-start;
+    gap: 11px;
+    margin-bottom: 14px;
+}
+.mptbm_taxi_card_icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    flex-shrink: 0;
+    border-radius: var(--mp-r-md);
+    background: var(--mp-primary-light);
+    color: var(--mp-primary);
+    border: 1px solid var(--mp-primary-border);
+}
+.mptbm_taxi_card_icon svg { display: block; }
+.mptbm_taxi_card_head_text {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding-top: 1px;
 }
 
 .mptbm_taxi_category_label {
-    display: flex;
     font-size: 14px;
-    font-weight: 600;
-    color: #1e293b;
-    margin-bottom: 2px;
+    font-weight: 700;
+    color: var(--mp-text-800);
+    margin: 0;
+    line-height: 1.2;
 }
-
-.mptbm_taxi_all_category_label {
-    display: flex;
-    font-size: 14px;
-    color: #1ba9bb;
-    margin-bottom: 2px;
-}
-
-.mptbm_taxi_all_category_label:hover{
-    text-decoration: underline;
-    color: #0b5ed7;
-    cursor: pointer;
-}
-
 .mptbm_taxi_category_subtext {
     display: block;
-    font-size: 12px;
-    color: #64748b;
-    margin-bottom: 12px;
+    font-size: 11.5px;
+    color: var(--mp-text-500);
+    margin: 0;
+    line-height: 1.4;
 }
+
+/* "All Categories" -> pill button */
+.mptbm_taxi_all_category_label {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    flex-shrink: 0;
+    padding: 5px 11px;
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--mp-primary);
+    background: var(--mp-primary-light);
+    border: 1px solid var(--mp-primary-border);
+    border-radius: var(--mp-r-full);
+    cursor: pointer;
+    line-height: 1;
+    transition: var(--mp-transition);
+}
+.mptbm_taxi_all_category_label:hover {
+    background: var(--mp-primary);
+    color: #fff;
+    border-color: var(--mp-primary);
+    text-decoration: none;
+}
+.mptbm_taxi_all_category_label svg { display: block; }
 
 .mptbm_taxi_category_helptext {
     font-size: 11px;
-    color: #94a3b8;
-    margin-top: 8px;
-    margin-bottom: 0;
+    color: var(--mp-text-400);
+    margin: 9px 0 0;
+    line-height: 1.4;
 }
 
-/* Flex group for dropdown + add button */
+/* Dropdown + add button */
 .mptbm_taxi_category_flex_group {
     display: flex;
     gap: 8px;
+    align-items: stretch;
+}
+.mptbm_taxi_select_wrap {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+}
+.mptbm_taxi_select_chevron {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 15px;
+    height: 15px;
+    pointer-events: none;
+    color: var(--mp-text-400);
 }
 
-/* Input & Select Styling */
 .mptbm_taxi_category_select,
 .mptbm_taxi_category_input {
     width: 100%;
-    height: 40px;
-    padding: 0 12px;
-    border: 1px solid #cbd5e1;
-    border-radius: 6px;
-    font-size: 14px;
-    color: #334155;
-    background-color: #fff;
+    height: 42px;
+    padding: 0 14px;
+    border: 1px solid var(--mp-border-dark);
+    border-radius: var(--mp-r-md);
+    font-size: 13.5px;
+    font-weight: 500;
+    color: var(--mp-text-700);
+    background-color: var(--mp-white);
     outline: none;
     box-sizing: border-box;
-    transition: border-color 0.2s ease;
+    transition: var(--mp-transition);
 }
-
+.mptbm_taxi_category_select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    padding-right: 36px;
+    cursor: pointer;
+}
+.mptbm_taxi_category_select:hover { border-color: var(--mp-primary-border); }
 .mptbm_taxi_category_select:focus,
 .mptbm_taxi_category_input:focus {
-    border-color: #4f46e5;
+    border-color: var(--mp-primary);
+    box-shadow: var(--mp-shadow-focus);
 }
 
-/* Action Buttons */
 .mptbm_taxi_category_btn_add {
-    width: 40px;
-    height: 40px;
-    background: #4f46e5;
-    color: #ffffff;
+    width: 42px;
+    height: 42px;
+    flex-shrink: 0;
+    background: var(--mp-primary);
+    color: #fff;
     border: none;
-    border-radius: 6px;
-    font-size: 20px;
-    font-weight: bold;
+    border-radius: var(--mp-r-md);
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: background 0.2s;
+    transition: var(--mp-transition);
+    box-shadow: 0 1px 3px rgba(var(--mp-primary-rgb), 0.3);
 }
-
 .mptbm_taxi_category_btn_add:hover {
-    background: #4338ca;
+    background: var(--mp-primary-dark);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 10px rgba(var(--mp-primary-rgb), 0.35);
 }
+.mptbm_taxi_category_btn_add:active { transform: translateY(0); }
+.mptbm_taxi_category_btn_add svg { display: block; }
 
 .mptbm_taxi_category_btn_save {
-    background: #4f46e5;
+    background: var(--mp-primary);
     color: #ffffff;
     border: none;
     padding: 10px 16px;
     font-size: 14px;
-    font-weight: 500;
-    border-radius: 6px;
+    font-weight: 600;
+    border-radius: var(--mp-r-md);
     cursor: pointer;
-    transition: background 0.2s;
+    transition: var(--mp-transition);
 }
+.mptbm_taxi_category_btn_save:hover { background: var(--mp-primary-dark); }
 
-.mptbm_taxi_category_btn_save:hover {
-    background: #4338ca;
+/* Tag input with leading icon */
+.mptbm_taxi_category_tag_input_wrapper { position: relative; }
+.mptbm_taxi_tag_input_icon {
+    position: absolute;
+    left: 13px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 15px;
+    height: 15px;
+    color: var(--mp-text-400);
+    pointer-events: none;
 }
+.mptbm_taxi_category_tag_input_wrapper .mptbm_taxi_category_input { padding-left: 38px; }
 
-/* Tag Badges */
+/* Tag chips */
 .mptbm_taxi_category_tags_container {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: 7px;
     margin-top: 12px;
 }
+.mptbm_taxi_category_tags_container:empty { margin-top: 0; }
 
 .mptbm_taxi_category_badge {
-    background: #eeeffe;
-    color: #4f46e5;
+    background: var(--mp-primary-light);
+    color: var(--mp-primary);
     font-size: 12px;
-    font-weight: 500;
-    padding: 6px 10px;
-    border-radius: 20px;
+    font-weight: 600;
+    padding: 5px 6px 5px 12px;
+    border: 1px solid var(--mp-primary-border);
+    border-radius: var(--mp-r-full);
     display: inline-flex;
     align-items: center;
     gap: 6px;
+    line-height: 1.4;
+    transition: var(--mp-transition);
 }
+.mptbm_taxi_category_badge:hover { background: #e6e4fd; }
 
 .mptbm_taxi_category_remove_tag {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: rgba(var(--mp-primary-rgb), 0.14);
+    color: var(--mp-primary);
     cursor: pointer;
     font-style: normal;
-    font-weight: bold;
-    color: #a5b4fc;
-    transition: color 0.2s;
+    font-weight: 700;
+    font-size: 13px;
+    line-height: 1;
+    transition: var(--mp-transition);
 }
-
 .mptbm_taxi_category_remove_tag:hover {
-    color: #4338ca;
+    background: var(--mp-danger);
+    color: #fff;
 }
 
 /* Popup Modal Layout */

--- a/assets/admin/mptbm_taxi_add_edit.css
+++ b/assets/admin/mptbm_taxi_add_edit.css
@@ -178,39 +178,102 @@
     height: 52px;
     padding: 0 20px;
     border-bottom: 1px solid var(--mp-border-light);
-    gap: 12px;
+    gap: 16px;
 }
 
-/* Back link */
-.mptbm_fixed_header_top a.mptbm-link {
+/* Left cluster: back button + title block */
+.mptbm_header_lead {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    min-width: 0;
+    flex: 1;
+}
+
+.mptbm_back_btn {
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    color: var(--mp-text-500);
-    text-decoration: none;
-    font-size: 13px;
-    font-weight: 500;
-    padding: 6px 12px;
+    justify-content: center;
     border-radius: var(--mp-r-md);
+    border: 1px solid var(--mp-border-dark);
+    background: var(--mp-white);
+    color: var(--mp-text-600);
+    text-decoration: none;
+    box-shadow: none;
     transition: var(--mp-transition);
-    white-space: nowrap;
 }
-.mptbm_fixed_header_top a.mptbm-link:hover {
+.mptbm_back_btn:hover {
     color: var(--mp-primary);
+    border-color: var(--mp-primary-border);
     background: var(--mp-primary-light);
 }
-.mptbm_fixed_header_top a.mptbm-link .dashicons {
-    width: 16px;
-    height: 16px;
-    font-size: 16px;
+.mptbm_back_btn:focus { box-shadow: none; outline: none; }
+.mptbm_back_btn svg {
+    display: block;
+    width: 18px;
+    height: 18px;
 }
 
-/* Page Title */
-.mptbm_header_left { flex: 1; min-width: 0; }
+.mptbm_header_titlewrap {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1px;
+    min-width: 0;
+    line-height: 1.2;
+}
 
-.mptbm_page_title {
+.mptbm_header_eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: .07em;
+    text-transform: uppercase;
+    color: var(--mp-text-500);
+}
+
+/* Status pill */
+.mptbm_status_pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 1px 8px;
+    border-radius: 100px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: .02em;
+    text-transform: none;
+    line-height: 1.6;
+}
+.mptbm_status_pill::before {
+    content: '';
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: .9;
+}
+.mptbm_status_pill.is-publish { color: #15803d; background: #dcfce7; }
+.mptbm_status_pill.is-draft   { color: #b45309; background: #fef3c7; }
+.mptbm_status_pill.is-pending { color: #1d4ed8; background: #dbeafe; }
+.mptbm_status_pill.is-private { color: #6d28d9; background: #ede9fe; }
+
+/* Page Title
+   Scoped under .mptbm_fixed_header_top so it beats WordPress core's
+   `.wrap h1` (23px + 9px/4px padding), which would otherwise overflow
+   the fixed-height header row and clip the eyebrow above it. */
+.mptbm_header_left { flex: 1; min-width: 0; }  /* legacy hook, kept harmless */
+
+.mptbm_fixed_header_top .mptbm_page_title {
     margin: 0;
+    padding: 0;
     font-size: 16px;
+    line-height: 1.25;
     font-weight: 700;
     color: var(--mp-text-800);
     white-space: nowrap;
@@ -224,6 +287,29 @@
     align-items: center;
     gap: 8px;
     flex-shrink: 0;
+}
+
+/* Soft-primary "Add New" button, normalised for the header row */
+.mptbm_fixed_header_top .mptbm_header_right a.mptbm-add-btn {
+    margin: 0;
+    height: 34px;
+    line-height: 1;
+    padding: 0 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    border-radius: var(--mp-r-md);
+    background: var(--mp-primary-light);
+    color: var(--mp-primary);
+    border: 1px solid var(--mp-primary-border);
+    vertical-align: middle;
+}
+.mptbm_fixed_header_top .mptbm_header_right a.mptbm-add-btn:hover {
+    background: var(--mp-primary);
+    color: var(--mp-white);
+    border-color: var(--mp-primary);
 }
 
 .mptbm_fixed_header_top .mptbm_header_right .button {
@@ -241,6 +327,14 @@
     cursor: pointer;
     display: inline-flex;
     align-items: center;
+    gap: 6px;
+}
+/* Icons inside header action buttons render as centered blocks so they
+   align to the text baseline via flexbox (no dashicons vertical-align quirk). */
+.mptbm_fixed_header_top .mptbm_header_right a.mptbm-add-btn svg,
+.mptbm_fixed_header_top .mptbm_header_right .button svg {
+    display: block;
+    flex-shrink: 0;
 }
 .mptbm_fixed_header_top .mptbm_header_right .button:hover {
     background: var(--mp-bg-muted);
@@ -2615,14 +2709,28 @@ input.mptbm_taxi_feature_input:focus {
         padding: 8px 14px;
     }
     .mptbm_fixed_header_top .mptbm_page_title { font-size: 14px; }
+    .mptbm_header_lead { gap: 10px; }
+    .mptbm_back_btn { width: 32px; height: 32px; }
+    .mptbm_back_btn .dashicons { width: 18px; height: 18px; font-size: 18px; }
     .mptbm_fixed_header_top .mptbm_header_right { flex-wrap: wrap; gap: 6px; }
     .mptbm_fixed_header_top .mptbm_header_right .button,
     .mptbm_fixed_header_top .mptbm_header_right .button-primary,
+    .mptbm_fixed_header_top .mptbm_header_right a.mptbm-add-btn,
     .mptbm_fixed_header_top .mptbm_header_right input[type="submit"] {
         font-size: 12px;
         height: 30px;
         line-height: 28px;
         padding: 0 10px;
+    }
+    /* Collapse the two secondary buttons to icon-only to keep the row tidy */
+    .mptbm_fixed_header_top .mptbm_header_right a.mptbm-add-btn .mptbm_btn_label,
+    .mptbm_fixed_header_top .mptbm_header_right .mptbm_btn_ghost .mptbm_btn_label {
+        display: none;
+    }
+    .mptbm_fixed_header_top .mptbm_header_right a.mptbm-add-btn,
+    .mptbm_fixed_header_top .mptbm_header_right .mptbm_btn_ghost {
+        gap: 0;
+        padding: 0 9px;
     }
 
     .mptbm_fixed_header .mptbm_taxi_header_holder {
@@ -2656,6 +2764,8 @@ input.mptbm_taxi_feature_input:focus {
         padding: 10px 14px;
     }
     .mptbm_fixed_header_top .mptbm_header_left { text-align: center; }
+    .mptbm_header_lead { justify-content: center; flex: none; }
+    .mptbm_header_titlewrap { align-items: center; }
     .mptbm_fixed_header_top .mptbm_header_right { justify-content: center; }
 
     .mptbm_scroll_content { margin-top: 170px; padding: 16px 0 140px; }
@@ -3101,4 +3211,119 @@ select.formControl,
 @media (max-width: 600px) {
     .mptbm-oa-grid { grid-template-columns: 1fr 1fr; }
     .mptbm-oa-card-inner { padding-top: 34px; }
+}
+
+/* ================================================================
+   SECTION: INSTANT SAVE — toast, required-field error, saving state
+   ================================================================ */
+
+/* Toast notifications (bottom-right) */
+.mptbm_toast {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    z-index: 1000000;
+    display: flex;
+    align-items: center;
+    gap: 11px;
+    max-width: min(420px, calc(100vw - 40px));
+    padding: 13px 18px;
+    border-radius: 12px;
+    background: var(--mp-white, #fff);
+    border: 1px solid var(--mp-border, #e2e8f0);
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12), 0 18px 40px rgba(15, 23, 42, 0.14);
+    font-family: var(--mp-font, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif);
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--mp-text-800, #1e293b);
+    cursor: pointer;
+    opacity: 0;
+    transform: translateY(16px) scale(0.98);
+    transition: opacity 0.28s cubic-bezier(0.16, 1, 0.3, 1), transform 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.mptbm_toast.is-show { opacity: 1; transform: translateY(0) scale(1); }
+.mptbm_toast_icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.mptbm_toast_icon svg { width: 16px; height: 16px; display: block; }
+.mptbm_toast_msg { line-height: 1.45; }
+
+/* Filled, high-contrast variants so a save is unmistakable every time */
+.mptbm_toast_success {
+    background: linear-gradient(135deg, #22c55e 0%, #15803d 100%);
+    border-color: #15803d;
+    color: #fff;
+    box-shadow: 0 8px 22px rgba(21, 128, 61, 0.30), 0 18px 42px rgba(21, 128, 61, 0.22);
+}
+.mptbm_toast_success .mptbm_toast_icon { background: rgba(255, 255, 255, 0.22); color: #fff; }
+
+.mptbm_toast_error {
+    background: linear-gradient(135deg, #ef4444 0%, #b91c1c 100%);
+    border-color: #b91c1c;
+    color: #fff;
+    box-shadow: 0 8px 22px rgba(185, 28, 28, 0.30), 0 18px 42px rgba(185, 28, 28, 0.22);
+}
+.mptbm_toast_error .mptbm_toast_icon { background: rgba(255, 255, 255, 0.22); color: #fff; }
+
+/* Icon pop on show to grab the eye */
+.mptbm_toast.is-show .mptbm_toast_icon { animation: mptbmToastPop 0.5s cubic-bezier(0.16, 1, 0.3, 1); }
+@keyframes mptbmToastPop {
+    0%   { transform: scale(0.4); }
+    60%  { transform: scale(1.18); }
+    100% { transform: scale(1); }
+}
+
+/* Required-field error highlight */
+.mptbm_field_error,
+.mptbm_rent_input.mptbm_field_error,
+select.mptbm_field_error,
+textarea.mptbm_field_error {
+    border-color: #ef4444 !important;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.14) !important;
+    background: #fff5f5 !important;
+    animation: mptbmFieldShake 0.35s ease;
+}
+@keyframes mptbmFieldShake {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-4px); }
+    75% { transform: translateX(4px); }
+}
+
+/* Saving state — spinner on the primary button, dimmed footer nav */
+.mptbm_header_right input[type="submit"]:disabled,
+.mptbm_header_right .button-primary:disabled {
+    opacity: 0.85;
+    cursor: progress;
+    position: relative;
+    padding-left: 32px;
+}
+.mptbm_header_right input[type="submit"]:disabled::before,
+.mptbm_header_right .button-primary:disabled::before {
+    content: '';
+    position: absolute;
+    left: 13px;
+    top: 50%;
+    width: 13px;
+    height: 13px;
+    margin-top: -7px;
+    border: 2px solid rgba(255, 255, 255, 0.45);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: mptbmBtnSpin 0.7s linear infinite;
+}
+@keyframes mptbmBtnSpin { to { transform: rotate(360deg); } }
+.mptbm_rent_form.mptbm_is_saving .mptbm_taxi_btn_next,
+.mptbm_rent_form.mptbm_is_saving .mptbm_taxi_btn_prev {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+@media (max-width: 600px) {
+    .mptbm_toast { right: 12px; left: 12px; bottom: 12px; max-width: none; }
 }

--- a/assets/admin/mptbm_taxi_add_edit.js
+++ b/assets/admin/mptbm_taxi_add_edit.js
@@ -87,6 +87,174 @@
 
         updateStep(1);
 
+        /* ===============================================================
+           Instant AJAX save + required-field validation.
+           Intercepts the form submit (header "Update" and the last-step
+           footer button both trigger it), validates required fields,
+           jumps to the first missing one, or saves without a reload and
+           shows a success / error toast.
+           =============================================================== */
+        (function () {
+            var $form = $('.mptbm_rent_form');
+            if (!$form.length) { return; }
+
+            var cfg  = window.mptbm_editor_l10n || {};
+            var i18n = cfg.i18n || {};
+
+            // ---- Toast ----
+            function dismissToast($t) {
+                $t.removeClass('is-show');
+                setTimeout(function () { $t.remove(); }, 300);
+            }
+            function showToast(type, message) {
+                $('.mptbm_toast').each(function () { dismissToast($(this)); });
+                var isOk = type === 'success';
+                var icon = isOk
+                    ? '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>'
+                    : '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>';
+                var $t = $('<div class="mptbm_toast ' + (isOk ? 'mptbm_toast_success' : 'mptbm_toast_error') + '" role="status" aria-live="polite"></div>');
+                $t.html('<span class="mptbm_toast_icon">' + icon + '</span><span class="mptbm_toast_msg"></span>');
+                $t.find('.mptbm_toast_msg').text(message || '');
+                $('body').append($t);
+                $t[0].offsetHeight; // reflow so the transition plays
+                $t.addClass('is-show');
+                var timer = setTimeout(function () { dismissToast($t); }, 4200);
+                $t.on('click', function () { clearTimeout(timer); dismissToast($t); });
+            }
+
+            // ---- Required-field helpers ----
+            function fieldLabel(el) {
+                var $el = $(el), id = $el.attr('id'), txt = '';
+                if (id) { txt = $('label[for="' + id + '"]').first().clone().children().remove().end().text(); }
+                if (!txt) { txt = $el.closest('.mptbm_rent_field_group, .mptbm_taxi_field, .mptbm_taxi_form_group, .formGroup').find('label').first().clone().children().remove().end().text(); }
+                if (!txt) { txt = $el.attr('placeholder') || $el.attr('name') || ''; }
+                return $.trim(txt).replace(/\*+\s*$/, '').trim();
+            }
+            function isEmptyField(el) {
+                var $el = $(el), type = (el.type || '').toLowerCase();
+                if (type === 'checkbox' || type === 'radio') {
+                    var name = $el.attr('name');
+                    return name ? $form.find('input[name="' + name + '"]:checked').length === 0 : !el.checked;
+                }
+                return $.trim($el.val() || '') === '';
+            }
+            // Skip hidden inputs, disabled/readonly controls, self-hidden fields,
+            // and required fields inside a collapsed sub-section (unreachable) —
+            // only the wizard-step wrapper being hidden should not disqualify.
+            function isValidatable(el) {
+                var $el = $(el), type = (el.type || '').toLowerCase();
+                if (type === 'hidden' || el.disabled || el.readOnly) { return false; }
+                if ($el.css('display') === 'none') { return false; }
+                var $step = $el.closest('[data-step]');
+                var reachable = true;
+                $el.parentsUntil($step).each(function () {
+                    if ($(this).css('display') === 'none') { reachable = false; return false; }
+                });
+                return reachable;
+            }
+            function firstInvalidRequired() {
+                var found = null;
+                $form.find('[required]').each(function () {
+                    if (!isValidatable(this)) { return; }
+                    if (isEmptyField(this)) { found = this; return false; }
+                });
+                return found;
+            }
+            function goToField(el) {
+                var $el = $(el);
+                var step = parseInt($el.closest('[data-step]').data('step'), 10);
+                if (step >= 1) { updateStep(step); }
+                $el.addClass('mptbm_field_error');
+                var $header = $('.mptbm_fixed_header');
+                var offset = ($header.length ? $header.outerHeight() : 0) + 24;
+                $('html, body').animate({ scrollTop: Math.max(0, $el.offset().top - offset) }, 300, function () {
+                    try { $el.trigger('focus'); } catch (e) {}
+                });
+            }
+            $form.on('input change', '.mptbm_field_error', function () {
+                $(this).removeClass('mptbm_field_error');
+            });
+
+            // ---- Saving state ----
+            var $saveBtns = $('.mptbm_header_right').find('input[type="submit"], .button-primary');
+            function setSaving(on) {
+                $form.toggleClass('mptbm_is_saving', on);
+                if (on) {
+                    $saveBtns.each(function () {
+                        var $b = $(this);
+                        if ($b.data('mptbmLabel') == null) { $b.data('mptbmLabel', $b.is('input') ? $b.val() : $b.text()); }
+                        if ($b.is('input')) { $b.val(i18n.saving || 'Saving…'); } else { $b.text(i18n.saving || 'Saving…'); }
+                    }).prop('disabled', true);
+                } else {
+                    $saveBtns.each(function () {
+                        var $b = $(this), lbl = $b.data('mptbmLabel');
+                        if (lbl != null) { if ($b.is('input')) { $b.val(lbl); } else { $b.text(lbl); } }
+                    }).prop('disabled', false);
+                }
+            }
+
+            // ---- Submit ----
+            var submitting = false;
+            $form.on('submit', function (e) {
+                e.preventDefault();
+                if (submitting) { return; }
+
+                var invalid = firstInvalidRequired();
+                if (invalid) {
+                    goToField(invalid);
+                    var name = fieldLabel(invalid);
+                    var msg = name
+                        ? (i18n.required || 'Please complete the required field: %s').replace('%s', name)
+                        : (i18n.required_generic || 'Please complete the highlighted required field.');
+                    showToast('error', msg);
+                    return;
+                }
+
+                if (window.tinyMCE && window.tinyMCE.triggerSave) { try { window.tinyMCE.triggerSave(); } catch (err) {} }
+
+                var fd = new FormData(this);
+                fd.set('action', cfg.action || 'mptbm_ajax_save_rent');
+
+                submitting = true;
+                setSaving(true);
+
+                $.ajax({
+                    url: cfg.ajax_url || window.ajaxurl,
+                    type: 'POST',
+                    data: fd,
+                    processData: false,
+                    contentType: false,
+                    dataType: 'json'
+                }).done(function (res) {
+                    if (res && res.success) {
+                        var d = res.data || {};
+                        showToast('success', d.message || i18n.saved);
+                        if (d.title) { $('.mptbm_page_title').text(d.title); }
+                        if (d.status_slug) {
+                            $('.mptbm_status_pill')
+                                .removeClass('is-publish is-draft is-pending is-private')
+                                .addClass('is-' + d.status_slug)
+                                .text(d.status_label || '');
+                        }
+                        if (d.post_id) { $('input[name="post_id"]').val(d.post_id); }
+                    } else {
+                        var d2 = (res && res.data) || {};
+                        showToast('error', d2.message || i18n.network_error);
+                        if (d2.field) {
+                            var $f = $form.find('[name="' + d2.field + '"]').first();
+                            if ($f.length) { goToField($f[0]); }
+                        }
+                    }
+                }).fail(function (xhr) {
+                    if (window.console) { console.error('[MPTBM] save failed', xhr && xhr.status, xhr && xhr.responseText); }
+                    showToast('error', i18n.network_error || 'Could not save. Please try again.');
+                }).always(function () {
+                    submitting = false;
+                    setSaving(false);
+                });
+            });
+        })();
+
         $('.mptbm_taxi_toggle_trigger').on('change', function() {
             const isChecked = $(this).is(':checked');
             const $parentSection = $(this).closest('.mptbm_taxi_toggle_box');

--- a/assets/admin/mptbm_transportation_lists.css
+++ b/assets/admin/mptbm_transportation_lists.css
@@ -19,6 +19,14 @@
 .mptbm-fleet a{box-shadow:none;}
 .mptbm-fleet a:focus{box-shadow:none;outline:none;}
 
+/* INLINE NOTICE (duplicate result, etc.) */
+.mptbm-notice{display:flex;align-items:center;gap:10px;padding:12px 16px;border-radius:12px;font-size:13.5px;font-weight:600;margin-bottom:18px;animation:mptbmFadeUp .35s ease both;}
+.mptbm-notice svg{flex-shrink:0;}
+.mptbm-notice.success{background:var(--mp-green-soft);color:#15803d;border:1px solid #bbf7d0;}
+.mptbm-notice.error{background:#fef2f2;color:#b91c1c;border:1px solid #fecaca;}
+.mptbm-notice a{margin-left:auto;font-weight:700;color:var(--mp-indigo) !important;text-decoration:none;white-space:nowrap;}
+.mptbm-notice a:hover{text-decoration:underline;}
+
 /* HEADER */
 .mptbm-page-header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:24px;flex-wrap:wrap;}
 .mptbm-page-title{font-size:25px;font-weight:800;color:var(--mp-ink);letter-spacing:-.02em;}
@@ -122,6 +130,8 @@
 .mptbm-act-btn.del:hover{background:#ef4444;}
 .mptbm-act-btn.restore{background:rgba(22,163,74,.95);color:#fff;}
 .mptbm-act-btn.restore:hover{background:var(--mp-green);}
+.mptbm-act-btn.dup{background:rgba(79,70,229,.95);color:#fff;}
+.mptbm-act-btn.dup:hover{background:var(--mp-indigo);}
 .mptbm-body{padding:16px;}
 .mptbm-name{display:block;font-size:16px;font-weight:700;color:var(--mp-ink) !important;margin-bottom:6px;line-height:1.3;text-decoration:none;}
 .mptbm-name:hover{color:var(--mp-indigo) !important;}
@@ -179,8 +189,10 @@ a.mptbm-table-del { border: 1px solid red; }
 .mptbm-table td:first-child a{color:var(--mp-ink) !important;text-decoration:none;}
 .mptbm-table td:first-child a:hover{color:var(--mp-indigo) !important;}
 .mptbm-table td:last-child{border-right:1px solid var(--mp-border);border-radius:0 12px 12px 0;}
-.mptbm-table-edit,.mptbm-table-del{padding:4px 12px;border-radius:6px;border:1px solid var(--mp-border);background:var(--mp-white);font-size:11px;font-weight:600;cursor:pointer;text-decoration:none;color:var(--mp-ink2) !important;display:inline-block;}
+.mptbm-table-edit,.mptbm-table-del,.mptbm-table-dup{padding:4px 12px;border-radius:6px;border:1px solid var(--mp-border);background:var(--mp-white);font-size:11px;font-weight:600;cursor:pointer;text-decoration:none;color:var(--mp-ink2) !important;display:inline-block;}
 .mptbm-table-edit:hover{border-color:var(--mp-indigo);color:var(--mp-indigo) !important;}
+.mptbm-table-dup{margin-left:4px;border-color:#c7d2fe;}
+.mptbm-table-dup:hover{border-color:var(--mp-indigo);color:var(--mp-indigo) !important;background:var(--mp-indigo-soft);}
 .mptbm-table-del{margin-left:4px;}
 .mptbm-table-del:hover{border-color:#ef4444;color:#ef4444 !important;}
 

--- a/inc/MPTBM_Dependencies.php
+++ b/inc/MPTBM_Dependencies.php
@@ -94,6 +94,17 @@ if (!class_exists('MPTBM_Dependencies')) {
             wp_enqueue_style('mptbm_date_and_advanced', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_date_and_advanced.css', array(), time());
             // Ensure jQuery UI Sortable is loaded before the add/edit script so drag handles work
             wp_enqueue_script('mptbm_taxi_add_edit', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_taxi_add_edit.js', array('jquery', 'jquery-ui-sortable'), time(), true);
+            wp_localize_script('mptbm_taxi_add_edit', 'mptbm_editor_l10n', array(
+                'ajax_url'   => admin_url('admin-ajax.php'),
+                'action'     => 'mptbm_ajax_save_rent',
+                'i18n'       => array(
+                    'saving'        => __('Saving…', 'ecab-taxi-booking-manager'),
+                    'saved'         => __('Transportation saved successfully.', 'ecab-taxi-booking-manager'),
+                    'required'      => __('Please complete the required field: %s', 'ecab-taxi-booking-manager'),
+                    'required_generic' => __('Please complete the highlighted required field.', 'ecab-taxi-booking-manager'),
+                    'network_error' => __('Could not reach the server. Please check your connection and try again.', 'ecab-taxi-booking-manager'),
+                ),
+            ));
             wp_enqueue_script('mptbm_admin', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_admin.js', array('jquery'), time(), true);
             wp_enqueue_script('mptbm_tooltip', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_tooltip.js', array('jquery'), time(), true);
             wp_enqueue_script('mptbm_transportation_lists', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_transportation_lists.js', array('jquery'), time(), true);

--- a/inc/MPTBM_Function.php
+++ b/inc/MPTBM_Function.php
@@ -445,9 +445,11 @@ if (!class_exists('MPTBM_Function')) {
 			if ($tier_price !== false) {
 				$price = $tier_price;
 			} else {
-				// Check if the session is active
-				if (session_status() !== PHP_SESSION_ACTIVE) {
-					// Start the session if it's not active
+				// Start the session only if it isn't active AND output hasn't started —
+				// session_start() sets a cookie header, so calling it after headers are
+				// sent emits a warning. If we can't start one, the code below degrades
+				// gracefully (the session is only used as a recompute cache here).
+				if (session_status() !== PHP_SESSION_ACTIVE && !headers_sent()) {
 					session_start();
 				}
 

--- a/templates/registration/choose_vehicles.php
+++ b/templates/registration/choose_vehicles.php
@@ -385,8 +385,9 @@ function wptbm_get_schedule($post_id, $days_name, $selected_day,$start_time_sche
     $timestamp = strtotime($selected_day);
     $selected_day = date('l', $timestamp);
     
-    // Check & destroy transport session if exist
-    if (session_status() !== PHP_SESSION_ACTIVE) {
+    // Check & destroy transport session if exist. Guard on headers_sent() too: this
+    // template can render after output has begun, where session_start() would warn.
+    if (session_status() !== PHP_SESSION_ACTIVE && !headers_sent()) {
         session_start();
     }
     if (isset($_SESSION["mptbm_fixed_distance_match_" . $post_id])) {


### PR DESCRIPTION
- Dummy import: auto-import demo data with a bottom-right circular progress widget (old popup removed)
- Transportation Lists: professional Duplicate action (mints a fresh hidden WC product, never shares the source's)
- Custom vehicle editor: reorganized header, instant AJAX save (no reload) with success/error toast, and required-field validation that jumps to the missing field
- Categories/Tags side panel: modernized markup and styles
- Payment setup notice: corrected copy, deep-links to Payment Settings, separate Pro messaging, modern card design
- Payment Settings: modernized WooCommerce-not-activated callout and light-palette gateway cards
- Fix: guard session_start() on !headers_sent() in MPTBM_Function and choose_vehicles.php to stop 'headers already sent' warnings