### PR TITLE
Fix documentation links to point to the correct docs site URL

### DIFF
--- a/Admin/settings/MPTBM_Right_Side_Content_Settings.php
+++ b/Admin/settings/MPTBM_Right_Side_Content_Settings.php
@@ -210,7 +210,7 @@ if ( ! class_exists('MPTBM_Right_Side_Content_Settings') ) {
                     <li><?php esc_html_e( 'What is the initial price in transport?', 'ecab-taxi-booking-manager' ); ?></li>
                 </ul>
 
-                <a href="https://docs.mage-people.com/ecab-taxi-booking-manager/" class="mptbm_quick_tips_btn">
+                <a href="https://docs.mage-people.com/plugins/ecab/overview" class="mptbm_quick_tips_btn">
                     <?php esc_html_e( 'View Documentation', 'ecab-taxi-booking-manager' ); ?>
                 </a>
 

--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,7 @@ https://mage-people.com/product/wordpress-taxi-cab-booking-plugin-for-woocommerc
 
 ## Make Yourself Comfortable With:
 🧶 [View Live Taxi Booking Demo](https://demo.ecabtaxi.com/)
-👉 [Plugin Documentation](https://ecabtaxi.com/docs/)
+👉 [Plugin Documentation](https://docs.mage-people.com/plugins/ecab/overview)
 
 ## Why Choose E-cab? (Key Features):
 **🗺️ Multiple Map Providers**
@@ -196,7 +196,7 @@ You can check the demo of this plugin from here:
 [View Live PRO Version Demo For Business](https://demo.ecabtaxi.com/)
 
 = Q.Any Documentation? =
-A. Yes! Here is the [Online Documentation](https://ecabtaxi.com/docs/).
+A. Yes! Here is the [Online Documentation](https://docs.mage-people.com/plugins/ecab/overview).
  
 = Q.I installed correctly but 404 error what can I do?  =
 A. You need to Re-save permalink settings it will solve the 404. if still does not work that means your permalink not working, or you may have an access problem or you have a server permission problem. 


### PR DESCRIPTION
## Summary
- Fixes the "Plugin Documentation"/"Online Documentation" links in readme.txt and the quick-tips link in Admin/settings/MPTBM_Right_Side_Content_Settings.php, which pointed to `ecabtaxi.com/docs/` and `docs.mage-people.com/ecab-taxi-booking-manager/` (neither is the live docs page). All now point to the correct URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)