### PR TITLE
Bump Tested up to 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Author URI : https://mage-people.com
 Tags: Taxi booking, Cab booking, Ride booking , Chauffeur service, Airport transfer, Distance based pricing, Fare calculator, Car booking, Map Booking, Limousine service, Transportation, Dispatch system
 Requires at least: 5.3
 Stable tag: trunk
-Tested up to: 6.8.2
+Tested up to: 7.0
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
- Updates "Tested up to" from 6.8.2 to 7.0 to reflect the current WordPress version, matching WordPress.org's published readme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)