### PR TITLE
feat: free Offline payment, standalone checkout, and admin UX

### DIFF
--- a/Admin/MPTBM_Admin.php
+++ b/Admin/MPTBM_Admin.php
@@ -60,6 +60,8 @@
 				require_once MPTBM_PLUGIN_DIR . '/Admin/MPTBM_WC_Payment_Manager.php';
 				require_once MPTBM_PLUGIN_DIR . '/Admin/settings/MPTBM_Payment_Settings.php';
 				require_once MPTBM_PLUGIN_DIR . '/Admin/MPTBM_Payment_Notice.php';
+				// Standalone, dismissible Pro upsell (free build only).
+				require_once MPTBM_PLUGIN_DIR . '/Admin/MPTBM_Pro_Features_Notice.php';
 				//****************Woocommerce Checkout*********************** */
 				// WooCommerce checkout integration only loads when WooCommerce is active.
 				if (MP_Global_Function::check_woocommerce() == 1) {

--- a/Admin/MPTBM_Payment_Notice.php
+++ b/Admin/MPTBM_Payment_Notice.php
@@ -30,7 +30,6 @@
 				$this->print_styles_once();
 
 				$payments_url = admin_url('edit.php?post_type=' . MPTBM_Function::get_cpt() . '&page=mptbm_settings_page&mptbm_tab=payments');
-				$pro_active   = class_exists('MPTBM_Plugin_Pro');
 				?>
 				<div class="notice is-dismissible mptbm-pay-notice">
 					<div class="mptbm-pn-inner">
@@ -49,22 +48,13 @@
 									<?php esc_html_e('Go to Payment Settings', 'ecab-taxi-booking-manager'); ?>
 								</a>
 
-								<?php if (MPTBM_Function::is_wc_active()) : ?>
-									<span class="mptbm-pn-hint"><?php esc_html_e('Enable a WooCommerce gateway there.', 'ecab-taxi-booking-manager'); ?></span>
-								<?php else : ?>
-									<span class="mptbm-pn-hint"><?php esc_html_e('Activate WooCommerce or enable Custom Payment there.', 'ecab-taxi-booking-manager'); ?></span>
-								<?php endif; ?>
+								<?php // Key the hint off the mode that is actually processing bookings, so it
+									// never tells an admin to fix the flow they aren't using. ?>
+								<span class="mptbm-pn-hint"><?php echo esc_html($this->get_action_hint()); ?></span>
 							</div>
 
-							<?php if (!$pro_active) : ?>
-								<div class="mptbm-pn-pro-row">
-									<span class="mptbm-pn-pro-chip"><?php esc_html_e('PRO', 'ecab-taxi-booking-manager'); ?></span>
-									<span class="mptbm-pn-pro-text"><?php esc_html_e('Want more gateways (Stripe, PayPal, offline) without WooCommerce?', 'ecab-taxi-booking-manager'); ?></span>
-									<a class="mptbm-pn-pro-link" href="https://mage-people.com/product/wordpress-taxi-cab-booking-plugin-for-woocommerce" target="_blank" rel="noopener noreferrer">
-										<?php esc_html_e('Explore Pro', 'ecab-taxi-booking-manager'); ?> &rarr;
-									</a>
-								</div>
-							<?php endif; ?>
+							<?php // The Pro pitch lives in its own notice (MPTBM_Pro_Features_Notice) so it
+								// isn't tied to - and doesn't disappear with - a payment misconfiguration. ?>
 						</div>
 					</div>
 				</div>
@@ -104,13 +94,6 @@
 				.mptbm-pn-btn-primary:hover{background:#4338ca;border-color:#4338ca;transform:translateY(-1px);
 					box-shadow:0 4px 10px rgba(79,70,229,.32);color:#fff !important;}
 				.mptbm-pn-hint{font-size:12px;color:#64748b;}
-				.mptbm-pn-pro-row{display:flex;flex-wrap:wrap;align-items:center;gap:9px;margin-top:12px;padding-top:12px;
-					border-top:1px dashed #eceff3;}
-				.mptbm-pn-pro-chip{display:inline-flex;align-items:center;background:#f59e0b;color:#fff;font-weight:800;
-					font-size:9px;letter-spacing:.07em;padding:3px 8px;border-radius:20px;text-transform:uppercase;}
-				.mptbm-pn-pro-text{font-size:12px;color:#64748b;}
-				.mptbm-pn-pro-link{font-size:12px;font-weight:700;color:#b45309 !important;text-decoration:none;}
-				.mptbm-pn-pro-link:hover{color:#92400e !important;text-decoration:underline;}
 				@media (max-width:782px){
 					.mptbm-pay-notice{margin-right:10px !important;}
 					.mptbm-pn-inner{padding-right:34px;}
@@ -127,10 +110,11 @@
 					return false;
 				}
 
-				if (class_exists('MPTBM_Booking_Mode') && MPTBM_Booking_Mode::needs_selection()) {
-					return true;
-				}
-
+				// Only a real blocker belongs in a site-wide alarm notice: no payment method
+				// for the flow that is actually processing bookings. An unconfirmed Booking
+				// Mode is NOT a blocker - get_mode() always resolves to a working flow - so
+				// asking for that choice stays as the inline nudge on the Payments screen,
+				// right next to the selector, instead of nagging across wp-admin.
 				return class_exists('MPTBM_Booking_Mode')
 					? !MPTBM_Booking_Mode::has_gateway_for_active_mode()
 					: !MPTBM_Payment_Status_Checker::has_available_payment_method();
@@ -147,10 +131,6 @@
 					return __('No payment method is set up yet, so customers can\'t complete a booking. Activate WooCommerce or enable a Custom Payment method in Payment Settings to start taking bookings.', 'ecab-taxi-booking-manager');
 				}
 
-				if (MPTBM_Booking_Mode::needs_selection()) {
-					return __('A Booking Mode hasn\'t been chosen yet. Pick WooCommerce or Custom Payment in Payment Settings so every booking follows one clear checkout path.', 'ecab-taxi-booking-manager');
-				}
-
 				if ('none' === MPTBM_Booking_Mode::availability()) {
 					return __('No payment method is set up yet, so customers can\'t complete a booking. Activate WooCommerce or enable a Custom Payment method in Payment Settings to start taking bookings.', 'ecab-taxi-booking-manager');
 				}
@@ -160,6 +140,19 @@
 				}
 
 				return __('Booking Mode is set to Custom Payment, but no gateway (PayPal, Stripe, or Offline) is enabled yet. Enable one in Payment Settings so customers can complete a booking.', 'ecab-taxi-booking-manager');
+			}
+
+			/** Short call-to-action next to the button, matching the active Booking Mode. */
+			private function get_action_hint(): string {
+				if (!class_exists('MPTBM_Booking_Mode') || 'none' === MPTBM_Booking_Mode::availability()) {
+					return __('Activate WooCommerce or enable Offline Payment there.', 'ecab-taxi-booking-manager');
+				}
+
+				if (MPTBM_Booking_Mode::is_woocommerce()) {
+					return __('Enable a WooCommerce gateway there.', 'ecab-taxi-booking-manager');
+				}
+
+				return __('Enable a Custom Payment method there.', 'ecab-taxi-booking-manager');
 			}
 
 			/**

--- a/Admin/MPTBM_Pro_Features_Notice.php
+++ b/Admin/MPTBM_Pro_Features_Notice.php
@@ -1,0 +1,183 @@
+<?php
+	/**
+	 * Dismissible "E-cab Taxi Booking Manager Pro" upsell notice.
+	 *
+	 * Replaces the small PRO row that used to live inside the payment-setup notice
+	 * (MPTBM_Payment_Notice). That row only appeared while payments were misconfigured,
+	 * so once an admin enabled the free Offline method the Pro pitch vanished with it.
+	 * This is a standalone notice instead: it shows whenever Pro is inactive, lists the
+	 * Pro feature set as a chip grid, and stays gone once dismissed.
+	 *
+	 * Shown only to admins, only on this plugin's own screens plus the Plugins list, and
+	 * never once dismissed (stored in the mptbm_pro_promo_dismissed option). Offline
+	 * Payment is deliberately NOT listed - it is a free method
+	 * (see MPTBM_Function::offline_payment_enabled()).
+	 */
+	if (!defined('ABSPATH')) {
+		die;
+	} // Cannot access pages directly.
+
+	if (!class_exists('MPTBM_Pro_Features_Notice')) {
+		class MPTBM_Pro_Features_Notice {
+
+			const DISMISS_OPTION = 'mptbm_pro_promo_dismissed';
+			const DISMISS_ACTION = 'mptbm_dismiss_pro_promo';
+
+			public function __construct() {
+				add_action('admin_init', array($this, 'handle_dismiss'));
+				add_action('admin_notices', array($this, 'render'));
+			}
+
+			private function is_pro(): bool {
+				return class_exists('MPTBM_Plugin_Pro') || class_exists('MPTBM_Dependencies_Pro');
+			}
+
+			/** Filterable upgrade destination, shared with the other free-build PRO locks. */
+			private function upgrade_url(): string {
+				return apply_filters('mptbm_pro_upgrade_url', 'https://www.magepeople.com/downloads/taxi-booking-manager-for-woocommerce/');
+			}
+
+			/** Persist the dismissal (nonce + capability checked) so the notice never returns. */
+			public function handle_dismiss(): void {
+				if (!isset($_GET[self::DISMISS_ACTION]) || $_GET[self::DISMISS_ACTION] !== '1') {
+					return;
+				}
+				if (isset($_GET['_wpnonce'])
+					&& wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['_wpnonce'])), self::DISMISS_ACTION)
+					&& current_user_can('manage_options')) {
+					update_option(self::DISMISS_OPTION, 'yes');
+				}
+			}
+
+			/** This plugin's own admin screens + the main Plugins list. */
+			private function is_target_screen(): bool {
+				if (!function_exists('get_current_screen')) {
+					return false;
+				}
+				$screen = get_current_screen();
+				if (!$screen) {
+					return false;
+				}
+				if (strpos((string) $screen->id, 'mptbm') !== false) {
+					return true;
+				}
+				if (class_exists('MPTBM_Function') && $screen->post_type === MPTBM_Function::get_cpt()) {
+					return true;
+				}
+				return $screen->id === 'plugins';
+			}
+
+			/** The Pro-only highlights (label + core Dashicon). */
+			private function features(): array {
+				return array(
+					array('icon' => 'cart',              'label' => __('PayPal & Stripe checkout', 'ecab-taxi-booking-manager')),
+					array('icon' => 'calendar-alt',      'label' => __('Booking calendar', 'ecab-taxi-booking-manager')),
+					array('icon' => 'list-view',         'label' => __('Full booking & order management', 'ecab-taxi-booking-manager')),
+					array('icon' => 'businessperson',    'label' => __('Driver panel & trip assignment', 'ecab-taxi-booking-manager')),
+					array('icon' => 'id',                'label' => __('Customer portal & My Bookings', 'ecab-taxi-booking-manager')),
+					array('icon' => 'media-document',    'label' => __('Branded PDF invoices & tickets', 'ecab-taxi-booking-manager')),
+					array('icon' => 'location-alt',      'label' => __('Operation areas & zone geo-fencing', 'ecab-taxi-booking-manager')),
+					array('icon' => 'media-spreadsheet', 'label' => __('Google Sheets sync', 'ecab-taxi-booking-manager')),
+					array('icon' => 'email-alt',         'label' => __('Notification centre & custom emails', 'ecab-taxi-booking-manager')),
+					array('icon' => 'format-gallery',    'label' => __('Vehicle gallery', 'ecab-taxi-booking-manager')),
+				);
+			}
+
+			public function render(): void {
+				if (!current_user_can('manage_options')) {
+					return;
+				}
+				if ($this->is_pro()) {
+					return; // Pro is active - nothing to upsell.
+				}
+				if (get_option(self::DISMISS_OPTION) === 'yes') {
+					return; // Dismissed for good.
+				}
+				if (!$this->is_target_screen()) {
+					return;
+				}
+
+				$this->print_styles_once();
+
+				$dismiss_url = wp_nonce_url(add_query_arg(self::DISMISS_ACTION, '1'), self::DISMISS_ACTION);
+				?>
+				<div class="notice mptbm-pro-notice">
+					<div class="mptbm-pro-inner">
+						<span class="mptbm-pro-icon" aria-hidden="true"><span class="dashicons dashicons-awards"></span></span>
+						<div class="mptbm-pro-body">
+							<span class="mptbm-pro-eyebrow"><?php esc_html_e('E-cab Taxi Booking Manager Pro', 'ecab-taxi-booking-manager'); ?></span>
+							<div class="mptbm-pro-title"><?php esc_html_e('Unlock every premium feature', 'ecab-taxi-booking-manager'); ?></div>
+							<p class="mptbm-pro-text"><?php esc_html_e('You\'re on the free plugin - Offline Payment and the WooCommerce checkout are included. Upgrade to Pro for online payments and the complete fleet toolkit:', 'ecab-taxi-booking-manager'); ?></p>
+							<ul class="mptbm-pro-chips">
+								<?php foreach ($this->features() as $feature) : ?>
+									<li class="mptbm-pro-chip">
+										<span class="dashicons dashicons-<?php echo esc_attr($feature['icon']); ?>" aria-hidden="true"></span>
+										<?php echo esc_html($feature['label']); ?>
+									</li>
+								<?php endforeach; ?>
+							</ul>
+							<div class="mptbm-pro-actions">
+								<a class="mptbm-pro-btn mptbm-pro-btn-primary" href="<?php echo esc_url($this->upgrade_url()); ?>" target="_blank" rel="noopener noreferrer">
+									<span class="dashicons dashicons-star-filled" aria-hidden="true"></span>
+									<?php esc_html_e('Get Pro Now', 'ecab-taxi-booking-manager'); ?>
+								</a>
+								<a class="mptbm-pro-btn mptbm-pro-btn-ghost" href="<?php echo esc_url($dismiss_url); ?>">
+									<?php esc_html_e('Maybe later', 'ecab-taxi-booking-manager'); ?>
+								</a>
+							</div>
+						</div>
+					</div>
+				</div>
+				<?php
+			}
+
+			/** Scoped CSS for the notice, printed at most once per request. */
+			private function print_styles_once(): void {
+				static $printed = false;
+				if ($printed) {
+					return;
+				}
+				$printed = true;
+				?>
+				<style id="mptbm-pro-promo-styles">
+				.mptbm-pro-notice{
+					border:1px solid #ece3fb !important;border-left:4px solid #7b2ff7 !important;
+					border-radius:12px !important;background:#fff !important;padding:0 !important;
+					margin:16px 20px 14px 0 !important;box-shadow:0 4px 16px rgba(16,24,40,.07) !important;overflow:hidden;
+				}
+				.mptbm-pro-inner{display:flex;gap:14px;align-items:flex-start;padding:18px 20px;
+					font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,sans-serif;}
+				.mptbm-pro-icon{flex:0 0 auto;width:40px;height:40px;border-radius:11px;
+					background:linear-gradient(135deg,#F12971 0%,#7b2ff7 100%);color:#fff;
+					display:flex;align-items:center;justify-content:center;}
+				.mptbm-pro-icon .dashicons{font-size:21px;width:21px;height:21px;line-height:1;}
+				.mptbm-pro-body{flex:1;min-width:0;}
+				.mptbm-pro-eyebrow{display:block;font-size:11px;font-weight:800;letter-spacing:.07em;
+					text-transform:uppercase;color:#7b2ff7;margin-bottom:3px;}
+				.mptbm-pro-title{font-size:15px;font-weight:700;color:#1e293b;margin:0 0 5px;line-height:1.3;}
+				.mptbm-pro-text{font-size:13px;color:#50575e;margin:0;line-height:1.55;max-width:840px;}
+				.mptbm-pro-chips{list-style:none;margin:12px 0 4px;padding:0;display:flex;flex-wrap:wrap;gap:8px;}
+				.mptbm-pro-chip{display:inline-flex;align-items:center;gap:8px;font-size:12.5px;color:#374151;
+					background:#faf5ff;border:1px solid #efe3fb;border-radius:8px;padding:7px 12px;line-height:1.35;white-space:nowrap;}
+				.mptbm-pro-chip .dashicons{font-size:16px;width:16px;height:16px;line-height:1;color:#F12971;flex:0 0 auto;}
+				.mptbm-pro-actions{display:flex;flex-wrap:wrap;align-items:center;gap:10px;margin-top:14px;}
+				.mptbm-pro-btn{display:inline-flex;align-items:center;gap:7px;height:34px;padding:0 16px;border-radius:8px;
+					font-size:13px;font-weight:600;text-decoration:none;line-height:1;box-sizing:border-box;
+					cursor:pointer;transition:all .18s ease;}
+				.mptbm-pro-btn .dashicons{font-size:15px;width:15px;height:15px;line-height:1;}
+				.mptbm-pro-btn-primary{background:linear-gradient(135deg,#F12971 0%,#7b2ff7 100%);color:#fff !important;
+					border:1px solid transparent;box-shadow:0 1px 3px rgba(123,47,247,.3);}
+				.mptbm-pro-btn-primary:hover{transform:translateY(-1px);box-shadow:0 4px 12px rgba(123,47,247,.34);color:#fff !important;}
+				.mptbm-pro-btn-ghost{background:#fff;color:#64748b !important;border:1px solid #e2e8f0;}
+				.mptbm-pro-btn-ghost:hover{background:#f8fafc;color:#475569 !important;}
+				@media (max-width:782px){
+					.mptbm-pro-notice{margin-right:10px !important;}
+					.mptbm-pro-chip{flex:1 1 100%;white-space:normal;}
+				}
+				</style>
+				<?php
+			}
+		}
+
+		new MPTBM_Pro_Features_Notice();
+	}

--- a/Admin/settings/MPTBM_Payment_Settings.php
+++ b/Admin/settings/MPTBM_Payment_Settings.php
@@ -18,7 +18,10 @@
 	 * from being wiped when the Settings API saves the rest of the form.
 	 *
 	 * PayPal & Stripe Configure are gated behind the Pro plugin (MPTBM_Plugin_Pro);
-	 * the free version shows a PRO badge. Offline payment is fully functional in free.
+	 * the free version shows a PRO badge for those two. Offline Payment is part of the
+	 * FREE plugin - it needs no online processor, so its card, Configure modal and AJAX
+	 * save all work without Pro (see MPTBM_Function::offline_payment_enabled()). Note the
+	 * standalone checkout that consumes an enabled Offline method still ships with Pro.
 	 */
 
 	if ( ! defined( 'ABSPATH' ) ) {
@@ -166,7 +169,7 @@
 					?>
 					<div class="mptbm-bm-auto-note mptbm-bm-auto-note--warn">
 						<span class="dashicons dashicons-warning"></span>
-						<p><?php esc_html_e( 'No booking flow is available yet: WooCommerce is not active and the Pro plugin is not active. Activate WooCommerce or the Pro plugin to start taking bookings.', 'ecab-taxi-booking-manager' ); ?></p>
+						<p><?php esc_html_e( 'No booking flow is available yet: WooCommerce is not active and no Custom Payment method is enabled. Activate WooCommerce, or enable Offline Payment below, to start taking bookings.', 'ecab-taxi-booking-manager' ); ?></p>
 					</div>
 					<?php
 					$this->booking_mode_styles();
@@ -177,7 +180,7 @@
 					?>
 					<div class="mptbm-bm-auto-note">
 						<span class="dashicons dashicons-yes-alt"></span>
-						<p><?php esc_html_e( 'Bookings are automatically processed through WooCommerce - it\'s the only booking flow available right now. Activate the Pro plugin to unlock the standalone Custom Payment flow (and a mode switch here).', 'ecab-taxi-booking-manager' ); ?></p>
+						<p><?php esc_html_e( 'Bookings are automatically processed through WooCommerce - it\'s the only booking flow available right now. Enable Offline Payment below (or activate the Pro plugin for PayPal & Stripe) to unlock the standalone Custom Payment flow and a mode switch here.', 'ecab-taxi-booking-manager' ); ?></p>
 					</div>
 					<?php
 					$this->booking_mode_styles();
@@ -300,13 +303,9 @@
 								$status.text( i18n.saved ).css( 'color', '#0a7c2f' );
 								setTimeout( function () { $status.fadeOut( 400, function () { $( this ).text( '' ).show(); } ); }, 1800 );
 
-								// Refresh the "Active" badge on the sub-tab bar.
-								$( '.mptbm-pay-subtab-badge' ).hide();
-								$( '.mptbm-pay-subtab-badge[data-badge-for="' + mode + '"]' ).show();
-
-								// Jump to the matching sub-tab so the admin can configure it right away.
-								var targetHref = ( mode === 'custom' ) ? '#no-woocommerce-field' : '#woocommerce-field';
-								$( '.payment-sub-tabs .nav-tab[href="' + targetHref + '"]' ).trigger( 'click' );
+								// Reveal the newly active mode's settings so the admin can configure
+								// it right away. payment_tabs_script() listens for this.
+								$( document ).trigger( 'mptbm:mode-changed', [ mode ] );
 
 								// Refresh the "no gateway enabled" warning for the freshly active mode.
 								var $slot = $wrap.find( '.mptbm-bm-gateway-warning-slot' );
@@ -368,36 +367,29 @@
 				.mptbm-bm-auto-note p{margin:0;font-weight:500;}
 				.mptbm-bm-auto-note--warn{background:#fff5f5;border-color:#fbcfcf;color:#8a1c1c;}
 				.mptbm-bm-auto-note--warn .dashicons{background:#fee2e2;color:#dc2626;}
-				.mptbm-pay-subtab-badge{margin-left:6px;font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.4px;background:rgba(255,255,255,0.9);color:#166534;padding:1px 7px;border-radius:20px;vertical-align:middle;}
 				@media (max-width:680px){.mptbm-bm-cards{grid-template-columns:1fr;}}
 				</style>
 				<?php
 			}
 
-			/** Sub-tab bar (WooCommerce / Custom Payment) + WC-inactive warning. */
+			/**
+			 * Anchor row for the settings sections + the WooCommerce-inactive warning.
+			 *
+			 * There used to be a WooCommerce / Custom Payment sub-tab bar here, but it
+			 * duplicated the Booking Mode selector directly below it: two controls for one
+			 * decision, which could disagree (you could sit on the WooCommerce tab while
+			 * Custom Payment was the mode actually taking bookings). The Booking Mode cards
+			 * are now the single switch - they save the mode AND reveal that mode's settings
+			 * (see payment_tabs_script()).
+			 */
 			public function render_sub_tabs() {
 				$wc_active    = $this->has_woo();
 				$is_installed = file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' );
 				$btn_text     = $is_installed
 					? __( 'Activate WooCommerce Now', 'ecab-taxi-booking-manager' )
 					: __( 'Install &amp; Activate Now', 'ecab-taxi-booking-manager' );
-
-				$needs_choice = class_exists( 'MPTBM_Booking_Mode' ) && MPTBM_Booking_Mode::needs_selection();
-				$mode         = class_exists( 'MPTBM_Booking_Mode' ) ? MPTBM_Booking_Mode::get_mode() : 'woocommerce';
-				$wc_is_mode     = ! $needs_choice && 'woocommerce' === $mode;
-				$custom_is_mode = ! $needs_choice && 'custom' === $mode;
 				?>
 				<div class="payment-sub-tabs-wrapper">
-					<h2 class="nav-tab-wrapper payment-sub-tabs">
-						<a href="#woocommerce-field" class="nav-tab<?php echo $custom_is_mode ? '' : ' nav-tab-active'; ?>">
-							<?php esc_html_e( 'WooCommerce', 'ecab-taxi-booking-manager' ); ?>
-							<span class="mptbm-pay-subtab-badge" data-badge-for="woocommerce"<?php echo $wc_is_mode ? '' : ' style="display:none;"'; ?>><?php esc_html_e( 'Active', 'ecab-taxi-booking-manager' ); ?></span>
-						</a>
-						<a href="#no-woocommerce-field" class="nav-tab<?php echo $custom_is_mode ? ' nav-tab-active' : ''; ?>">
-							<?php esc_html_e( 'Custom Payment', 'ecab-taxi-booking-manager' ); ?>
-							<span class="mptbm-pay-subtab-badge" data-badge-for="custom"<?php echo $custom_is_mode ? '' : ' style="display:none;"'; ?>><?php esc_html_e( 'Active', 'ecab-taxi-booking-manager' ); ?></span>
-						</a>
-					</h2>
 					<?php if ( ! $wc_active ) : ?>
 						<div class="woocommerce-field">
 							<div class="mptbm-wc-callout">
@@ -407,7 +399,7 @@
 									</span>
 									<h4 class="mptbm-wc-callout-title"><?php esc_html_e( 'WooCommerce is not activated', 'ecab-taxi-booking-manager' ); ?></h4>
 								</div>
-								<p class="mptbm-wc-callout-text"><?php esc_html_e( 'To take bookings through the WooCommerce cart & checkout flow, install and activate WooCommerce. Prefer not to use it? Switch to the Custom Payment tab.', 'ecab-taxi-booking-manager' ); ?></p>
+								<p class="mptbm-wc-callout-text"><?php esc_html_e( 'To take bookings through the WooCommerce cart & checkout flow, install and activate WooCommerce. Prefer not to use it? Choose Custom Payment (Standalone) as your Booking Mode above.', 'ecab-taxi-booking-manager' ); ?></p>
 								<button type="button" class="mptbm-install-wc-trigger mptbm-wc-callout-btn">
 									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v11"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
 									<?php echo wp_kses_post( $btn_text ); ?>
@@ -424,7 +416,7 @@
 				$is_pro      = $this->is_pro();
 				$pp_enabled  = $this->opt( 'mptbm_paypal_enable' ) === 'on';
 				$st_enabled  = $this->opt( 'mptbm_stripe_enable' ) === 'on';
-				$off_enabled = $this->opt( 'mptbm_offline_enable' ) === 'on';
+				$off_enabled = MPTBM_Function::offline_payment_enabled();
 				$conf_page   = absint( $this->opt( 'mptbm_confirmation_page_id', 0 ) );
 
 				$enabled_txt  = __( 'Enabled', 'ecab-taxi-booking-manager' );
@@ -505,15 +497,10 @@
 								<span class="gateway-sub"><?php esc_html_e( 'Bank transfer, cash, pay on pickup', 'ecab-taxi-booking-manager' ); ?></span>
 							</span>
 						</div>
-						<?php if ( $is_pro ) : ?>
-							<span class="gateway-status <?php echo $off_enabled ? 'active' : ''; ?>"><?php echo esc_html( $off_enabled ? $enabled_txt : $disabled_txt ); ?></span>
-						<?php endif; ?>
+						<!-- Offline needs no online processor, so it is available in the free plugin. -->
+						<span class="gateway-status <?php echo $off_enabled ? 'active' : ''; ?>"><?php echo esc_html( $off_enabled ? $enabled_txt : $disabled_txt ); ?></span>
 						<div class="gateway-actions">
-							<?php if ( $is_pro ) : ?>
-								<button type="button" class="gateway-configure-btn" id="mptbm-offline-configure-btn"><?php esc_html_e( 'Configure', 'ecab-taxi-booking-manager' ); ?></button>
-							<?php else : ?>
-								<?php echo wp_kses_post( $pro_badge ); ?>
-							<?php endif; ?>
+							<button type="button" class="gateway-configure-btn" id="mptbm-offline-configure-btn"><?php esc_html_e( 'Configure', 'ecab-taxi-booking-manager' ); ?></button>
 						</div>
 					</div>
 				</div>
@@ -538,7 +525,8 @@
 				</div>
 
 				<!-- Require customer login (custom booking flow + portal) -->
-				<?php $require_login = $this->opt( 'mptbm_require_login', 'yes' ); ?>
+				<?php // Defaults to guest checkout - the admin opts in to forced login. ?>
+				<?php $require_login = $this->opt( 'mptbm_require_login', 'no' ); ?>
 				<div class="mptbm-conf-page">
 					<div class="mptbm-conf-page-label">
 						<label><?php esc_html_e( 'Require Customer Login', 'ecab-taxi-booking-manager' ); ?></label>
@@ -682,7 +670,7 @@
 				$st_test_sec = esc_attr( $this->opt( 'mptbm_stripe_test_sec' ) );
 				$st_live_pub = esc_attr( $this->opt( 'mptbm_stripe_live_pub' ) );
 				$st_live_sec = esc_attr( $this->opt( 'mptbm_stripe_live_sec' ) );
-				$off_enabled = $this->opt( 'mptbm_offline_enable' ) === 'on';
+				$off_enabled = MPTBM_Function::offline_payment_enabled();
 				$off_label   = esc_attr( $this->opt( 'mptbm_offline_label', __( 'Offline Payment', 'ecab-taxi-booking-manager' ) ) );
 				$nonce       = wp_create_nonce( 'mptbm_save_gateway' );
 				$is_pro      = $this->is_pro();
@@ -804,7 +792,9 @@
 						</div>
 					</div>
 				</div>
-				<!-- Offline Payment Config Modal (Pro-only) -->
+				<?php endif; ?>
+
+				<!-- Offline Payment Config Modal (free - no online processor needed). -->
 				<div id="mptbm-offline-modal" class="mptbm-gw-modal">
 					<div class="mptbm-gw-modal-box">
 						<div class="mptbm-gw-modal-header" style="background:linear-gradient(135deg,#0f766e 0%,#115e59 100%);">
@@ -832,7 +822,6 @@
 						</div>
 					</div>
 				</div>
-				<?php endif; ?>
 
 				<script>
 				var mptbmGateway = <?php echo wp_json_encode( array(
@@ -932,12 +921,11 @@
 				div.tabsItem[data-tabs="#mptbm_payment_settings"] > form > .form-table > tbody > tr.wc-additional-last{border-bottom:1px solid #e7e8ec;border-radius:0 0 12px 12px;}
 				div.tabsItem[data-tabs="#mptbm_payment_settings"] > form > .form-table .formControl{max-width:340px;}
 				div.tabsItem[data-tabs="#mptbm_payment_settings"] .submit{margin:20px 0 0;padding-top:20px;border-top:1px solid #e7e8ec;}
-				/* Sub-tab bar */
-				.payment-sub-tabs-wrapper{margin:0 0 24px;background:#fff;padding:6px;border-radius:12px;border:1px solid #e7e8ec;box-shadow:0 1px 2px rgba(16,24,40,0.04);display:inline-block;}
-				.payment-sub-tabs.nav-tab-wrapper{border-bottom:none !important;padding:0 !important;margin:0 !important;display:flex;gap:6px;}
-				.payment-sub-tabs .nav-tab{background:transparent;border:1px solid transparent;border-radius:8px;padding:9px 20px;font-size:14px;font-weight:600;color:#50575e !important;text-decoration:none;margin:0;transition:all 0.18s ease;}
-				.payment-sub-tabs .nav-tab:hover{background:#fbeaf1;color:var(--mptbm-pay-accent) !important;}
-				.payment-sub-tabs .nav-tab-active,.payment-sub-tabs .nav-tab-active:hover{background:var(--mptbm-pay-accent);color:#fff !important;box-shadow:0 4px 12px rgba(241,41,113,0.28);}
+				/* Anchor for the mode-driven sections. It used to hold the WooCommerce /
+				   Custom Payment sub-tab bar; that was removed (the Booking Mode cards are
+				   the single switch), so it is now an unstyled hook - the accordion script
+				   still uses its row as the insertion point. Any spacing comes from the
+				   callout inside it, so with WooCommerce active it takes up no room. */
 
 				/* WooCommerce-not-activated callout (modern) */
 				.mptbm-wc-callout{background:linear-gradient(180deg,#fffdf6,#fff8e8);border:1px solid #f2e0b0;border-radius:14px;padding:18px;margin:16px 0 6px;box-shadow:0 1px 2px rgba(16,24,40,0.03);}
@@ -1031,7 +1019,12 @@
 					})();
 
 					var wcActive = <?php echo $wc_active; ?>;
-					if ($('.payment-sub-tabs').length === 0) { return; }
+					if ($('.payment-sub-tabs-wrapper').length === 0) { return; }
+
+					// The mode actually in effect, resolved server-side. Used when the Booking
+					// Mode cards aren't rendered (only one flow is available, so there is
+					// nothing to choose) - the correct section must still be the visible one.
+					var resolvedMode = <?php echo wp_json_encode( class_exists( 'MPTBM_Booking_Mode' ) ? MPTBM_Booking_Mode::get_mode() : 'woocommerce' ); ?>;
 
 					var $paymentSubmit = $('div.tabsItem[data-tabs="#<?php echo esc_js( self::OPTION ); ?>"] .submit');
 
@@ -1096,25 +1089,28 @@
 						});
 					}
 
+					// Which settings section is showing follows the Booking Mode - the selected
+					// card when the selector is on screen, otherwise the server-resolved mode.
+					function activeMode(){
+						var $selected = $('.mptbm-bm-card.is-selected');
+						return $selected.length ? String($selected.data('mode')) : resolvedMode;
+					}
+
 					function updateTabs(){
-						var activeTabId = $('.payment-sub-tabs .nav-tab-active').attr('href').replace('#','');
 						$('tr.woocommerce-field, div.woocommerce-field, tr.no-woocommerce-field').hide();
 						$paymentSubmit.show();
-						if (activeTabId === 'woocommerce-field') {
+						if (activeMode() === 'custom') {
+							$('tr.no-woocommerce-field').show();
+						} else {
 							$('div.woocommerce-field').show();
 							if (wcActive) { $('tr.woocommerce-field').stop(true,true).show(); refreshAccordions(); }
-						} else {
-							$('tr.' + activeTabId).show();
 						}
 					}
-					$('.payment-sub-tabs .nav-tab').on('click', function(e){
-						e.preventDefault();
-						$('.payment-sub-tabs .nav-tab').removeClass('nav-tab-active');
-						$(this).addClass('nav-tab-active');
-						updateTabs();
-					});
 
-					// Move the tab bar above the settings table so it spans full width.
+					// Fired by the Booking Mode selector once a new mode has been saved.
+					$(document).on('mptbm:mode-changed', updateTabs);
+
+					// Move the anchor above the settings table so its callout spans full width.
 					var $tabContainer = $('.payment-sub-tabs-wrapper');
 					var $table = $tabContainer.closest('table.form-table');
 					if ($table.length) {
@@ -1153,8 +1149,9 @@
 					wp_send_json_error( __( 'Invalid gateway.', 'ecab-taxi-booking-manager' ) );
 				}
 
-				// PayPal, Stripe & Offline are Pro-only; never persist them from the free build.
-				if ( ! $this->is_pro() ) {
+				// PayPal & Stripe configuration is Pro-only; never persist them from the free
+				// build. Offline needs no online processor, so it stays configurable in free.
+				if ( 'offline' !== $gateway && ! $this->is_pro() ) {
 					wp_send_json_error( __( 'This gateway is available in the Pro version.', 'ecab-taxi-booking-manager' ) );
 				}
 

--- a/Frontend/MPTBM_Frontend.php
+++ b/Frontend/MPTBM_Frontend.php
@@ -19,6 +19,9 @@
 				require_once MPTBM_PLUGIN_DIR . '/Frontend/MPTBM_Woocommerce.php';
 				require_once MPTBM_PLUGIN_DIR . '/Frontend/MPTBM_Wc_Checkout_Fields_Helper.php';
 				require_once MPTBM_PLUGIN_DIR . '/Frontend/MPTBM_Reviews.php';
+				// Free standalone checkout for the built-in Offline method. Stands down on
+				// its own when the Pro plugin (MPTBM_Native_Checkout) is active.
+				require_once MPTBM_PLUGIN_DIR . '/Frontend/MPTBM_Offline_Checkout.php';
 
 			}
 			public function load_single_template($template): string {

--- a/Frontend/MPTBM_Offline_Checkout.php
+++ b/Frontend/MPTBM_Offline_Checkout.php
@@ -1,0 +1,622 @@
+<?php
+	/**
+	 * Standalone (no-WooCommerce) checkout for the built-in FREE Offline payment method.
+	 *
+	 * Offline is the one custom payment method that ships with the free plugin: it needs
+	 * no online processor, so a booking can be recorded as "pending" and settled on
+	 * pickup / by bank transfer. PayPal & Stripe (and the richer Pro checkout - customer
+	 * portal, gateway returns, PDF, driver assignment) stay in the Pro plugin.
+	 *
+	 * Flow:
+	 *   1. Renders the customer fields + the Offline payment card into the last booking
+	 *      step, via the `mptbm_custom_checkout_form` action the free templates already fire.
+	 *   2. Handles the "Book Now" submit through the `mptbm_custom_payment_add_to_cart`
+	 *      filter that MPTBM_Woocommerce::mptbm_add_to_cart() applies whenever WooCommerce
+	 *      does not own the booking (see MPTBM_Booking_Mode).
+	 *   3. Recomputes the fare SERVER-SIDE (never trusts a posted price), stores the
+	 *      booking as an `mptbm_booking` post using the SAME meta schema as the
+	 *      WooCommerce flow (MPTBM_Woocommerce::add_cpt_data), so it shows up in the
+	 *      existing Bookings list, analytics, etc.
+	 *   4. Redirects to the Booking Confirmation page (auto-created, shortcode
+	 *      [mptbm_booking_confirmation]), keyed by booking id + PIN so a booking can't be
+	 *      read by guessing ids.
+	 *
+	 * Stands down COMPLETELY when the Pro plugin is active - Pro's MPTBM_Native_Checkout
+	 * owns the standalone flow there and registers the same shortcode. Pro is detected at
+	 * hook/request time (both plugins are loaded by then), never at include time, because
+	 * plugin load order is not guaranteed. Same approach as MPTBM_Booking_List_Free.
+	 */
+	if (!defined('ABSPATH')) {
+		die;
+	} // Cannot access pages directly.
+
+	if (!class_exists('MPTBM_Offline_Checkout')) {
+		class MPTBM_Offline_Checkout {
+
+			const CONFIRMATION_SHORTCODE = 'mptbm_booking_confirmation';
+			const SETTINGS_OPTION        = 'mptbm_payment_settings';
+			const AUTO_PAGE_OPTION       = 'mptbm_confirmation_page_auto';
+
+			public function __construct() {
+				add_action('mptbm_custom_checkout_form', array($this, 'render_checkout_form'));
+				add_filter('mptbm_custom_payment_add_to_cart', array($this, 'process_checkout'), 10, 2);
+				add_action('init', array($this, 'register_confirmation_shortcode'));
+				add_action('admin_init', array($this, 'ensure_confirmation_page'));
+			}
+
+			/*
+			 * ---------------------------------------------------------------
+			 * Availability
+			 * ------------------------------------------------------------ */
+
+			/** Pro owns the standalone flow when present, so this class must not run. */
+			private function pro_active(): bool {
+				return class_exists('MPTBM_Plugin_Pro') || class_exists('MPTBM_Native_Checkout');
+			}
+
+			/** Should this free Offline flow handle the booking right now? */
+			private function is_active(): bool {
+				if ($this->pro_active()) {
+					return false;
+				}
+				if (!MPTBM_Function::offline_payment_enabled()) {
+					return false;
+				}
+				// Only when the booking is NOT owned by the WooCommerce cart.
+				return !class_exists('MPTBM_Booking_Mode') || !MPTBM_Booking_Mode::is_woocommerce();
+			}
+
+			/** Customer-facing label for the offline method. */
+			private function offline_label(): string {
+				$label = MP_Global_Function::get_settings(self::SETTINGS_OPTION, 'mptbm_offline_label', '');
+				return $label ? $label : esc_html__('Offline Payment', 'ecab-taxi-booking-manager');
+			}
+
+			/**
+			 * Whether a customer must be signed in to book. Mirrors the Pro reader
+			 * (MPTBM_Customer_Portal::login_required()) so both builds agree; defaults to
+			 * NO, matching the "Require Customer Login" default on the Payments tab.
+			 */
+			private function login_required(): bool {
+				if (class_exists('MPTBM_Booking_Mode') && MPTBM_Booking_Mode::is_woocommerce()) {
+					return false;
+				}
+				return MP_Global_Function::get_settings(self::SETTINGS_OPTION, 'mptbm_require_login', 'no') === 'yes';
+			}
+
+			/*
+			 * ---------------------------------------------------------------
+			 * Frontend: customer details + payment method (final booking step)
+			 * ------------------------------------------------------------ */
+
+			public function render_checkout_form($post_id = 0): void {
+				if (!$this->is_active()) {
+					return;
+				}
+
+				if (!is_user_logged_in() && $this->login_required()) {
+					$this->render_login_required_panel();
+					return;
+				}
+
+				$name = $email = $phone = '';
+				if (is_user_logged_in()) {
+					$user  = wp_get_current_user();
+					$name  = $user->display_name;
+					$email = $user->user_email;
+					$phone = get_user_meta($user->ID, 'user_phone', true);
+				}
+				?>
+				<div class="dLayout mptbm_custom_checkout">
+					<div class="mptbm_cc_head">
+						<span class="mptbm_cc_head_icon"><span class="fas fa-user"></span></span>
+						<h3><?php esc_html_e('Your Details', 'ecab-taxi-booking-manager'); ?></h3>
+					</div>
+					<div class="mptbm_cc_fields">
+						<div class="mptbm_cc_field">
+							<label><?php esc_html_e('Full Name', 'ecab-taxi-booking-manager'); ?> <span class="mptbm_cc_req">*</span></label>
+							<input type="text" name="mptbm_billing_name" value="<?php echo esc_attr($name); ?>" placeholder="<?php esc_attr_e('John Doe', 'ecab-taxi-booking-manager'); ?>" required>
+						</div>
+						<div class="mptbm_cc_field">
+							<label><?php esc_html_e('Email', 'ecab-taxi-booking-manager'); ?> <span class="mptbm_cc_req">*</span></label>
+							<input type="email" name="mptbm_billing_email" value="<?php echo esc_attr($email); ?>" placeholder="<?php esc_attr_e('you@example.com', 'ecab-taxi-booking-manager'); ?>" required>
+						</div>
+						<div class="mptbm_cc_field mptbm_cc_field_full">
+							<label><?php esc_html_e('Phone', 'ecab-taxi-booking-manager'); ?></label>
+							<input type="text" name="mptbm_billing_phone" value="<?php echo esc_attr($phone); ?>" placeholder="<?php esc_attr_e('+1 234 567 890', 'ecab-taxi-booking-manager'); ?>">
+						</div>
+					</div>
+
+					<div class="mptbm_cc_head mptbm_cc_head_pay">
+						<span class="mptbm_cc_head_icon"><span class="fas fa-credit-card"></span></span>
+						<h3><?php esc_html_e('Payment Method', 'ecab-taxi-booking-manager'); ?></h3>
+					</div>
+					<div class="mptbm_payment_methods">
+						<label class="mptbm_pm_card is-selected" data-pm="offline">
+							<span class="mptbm_pm_icon">
+								<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="#fff" stroke-width="1.7" xmlns="http://www.w3.org/2000/svg"><rect x="2" y="6" width="20" height="13" rx="2"/><circle cx="12" cy="12.5" r="2.4"/><path d="M5 9.5h.01M19 15.5h.01"/></svg>
+							</span>
+							<span class="mptbm_pm_text">
+								<span class="mptbm_pm_name"><?php echo esc_html($this->offline_label()); ?></span>
+								<span class="mptbm_pm_sub"><?php esc_html_e('Pay on service / bank transfer', 'ecab-taxi-booking-manager'); ?></span>
+							</span>
+							<input type="radio" name="mptbm_payment_method" value="offline" checked>
+							<span class="mptbm_pm_radio"></span>
+						</label>
+					</div>
+				</div>
+				<?php
+				$this->checkout_form_assets();
+			}
+
+			/** Guest + "Require Customer Login" is on: point them at wp-login instead of a dead form. */
+			private function render_login_required_panel(): void {
+				$redirect = home_url(add_query_arg(array()));
+				?>
+				<div class="dLayout mptbm_custom_checkout">
+					<div class="mptbm_cc_head">
+						<span class="mptbm_cc_head_icon"><span class="fas fa-lock"></span></span>
+						<h3><?php esc_html_e('Please sign in to continue', 'ecab-taxi-booking-manager'); ?></h3>
+					</div>
+					<p class="mptbm_cc_login_text"><?php esc_html_e('An account is required to complete this booking. Sign in or create an account, then come back to finish.', 'ecab-taxi-booking-manager'); ?></p>
+					<p>
+						<a class="_themeButton_min_200" href="<?php echo esc_url(wp_login_url($redirect)); ?>"><?php esc_html_e('Sign in', 'ecab-taxi-booking-manager'); ?></a>
+						<?php if (get_option('users_can_register')) : ?>
+							<a class="_mpBtn_dBR_min_150" href="<?php echo esc_url(wp_registration_url()); ?>"><?php esc_html_e('Create an account', 'ecab-taxi-booking-manager'); ?></a>
+						<?php endif; ?>
+					</p>
+				</div>
+				<?php
+				$this->checkout_form_assets();
+			}
+
+			/** Checkout-form CSS, printed at most once per request. */
+			private function checkout_form_assets(): void {
+				static $printed = false;
+				if ($printed) {
+					return;
+				}
+				$printed = true;
+				?>
+				<style>
+				.mptbm_custom_checkout{--mptbm-cc-accent:#F12971;--mptbm-cc-border:#e5e7eb;padding:22px 22px 4px;}
+				.mptbm_cc_head{display:flex;align-items:center;gap:10px;margin:0 0 18px;}
+				.mptbm_cc_head_pay{margin-top:28px;}
+				.mptbm_cc_head h3{margin:0;font-size:16px;font-weight:700;color:#1f2937;}
+				.mptbm_custom_checkout .mptbm_cc_head_icon{width:32px;height:32px;border-radius:9px;display:inline-flex !important;align-items:center !important;justify-content:center !important;line-height:1;background:rgba(241,41,113,.1);color:var(--mptbm-cc-accent);font-size:14px;flex:0 0 auto;}
+				.mptbm_custom_checkout .mptbm_cc_head_icon .fas{display:block;line-height:1;margin:0;}
+				.mptbm_cc_fields{display:grid;grid-template-columns:1fr 1fr;gap:16px;}
+				.mptbm_cc_field{display:flex;flex-direction:column;gap:7px;}
+				.mptbm_cc_field_full{grid-column:1 / -1;}
+				.mptbm_cc_field label{font-size:13px;font-weight:600;color:#374151;}
+				.mptbm_cc_req{color:var(--mptbm-cc-accent);}
+				.mptbm_cc_field input{width:100%;box-sizing:border-box;height:46px;padding:0 14px;border:1.5px solid var(--mptbm-cc-border);border-radius:10px;font-size:14px;color:#111827;background:#fff;transition:border-color .15s,box-shadow .15s;}
+				.mptbm_cc_field input::placeholder{color:#9ca3af;}
+				.mptbm_cc_field input:focus{outline:none;border-color:var(--mptbm-cc-accent);box-shadow:0 0 0 3px rgba(241,41,113,.12);}
+				.mptbm_cc_login_text{margin:0 0 16px;font-size:14px;color:#4b5563;line-height:1.6;}
+				.mptbm_payment_methods{display:flex;flex-direction:column;gap:12px;}
+				.mptbm_pm_card{display:flex;align-items:center;gap:14px;padding:14px 16px;border:1.5px solid var(--mptbm-cc-border);border-radius:14px;background:#fff;cursor:pointer;position:relative;transition:border-color .15s,box-shadow .15s,background .15s;}
+				.mptbm_pm_card:hover{border-color:#cbd5e1;box-shadow:0 4px 14px rgba(16,24,40,.06);}
+				.mptbm_pm_card.is-selected{border-color:var(--mptbm-cc-accent);background:#fff;box-shadow:0 6px 18px rgba(241,41,113,.12);}
+				.mptbm_custom_checkout .mptbm_pm_icon{flex:0 0 auto;width:44px;height:44px;border-radius:11px;display:inline-flex !important;align-items:center !important;justify-content:center !important;line-height:1;background:linear-gradient(135deg,#0f766e,#115e59);box-shadow:0 4px 10px rgba(16,24,40,.18);overflow:hidden;}
+				.mptbm_custom_checkout .mptbm_pm_icon svg{display:block;width:20px;height:20px;margin:0;}
+				.mptbm_pm_text{display:flex;flex-direction:column;gap:2px;flex:1 1 auto;min-width:0;}
+				.mptbm_pm_name{font-size:15px;font-weight:700;color:#1f2937;line-height:1.2;}
+				.mptbm_pm_sub{font-size:12.5px;color:#6b7280;line-height:1.3;}
+				.mptbm_pm_card input[type=radio]{position:absolute;opacity:0;width:0;height:0;}
+				.mptbm_pm_radio{flex:0 0 auto;width:22px;height:22px;border-radius:50%;border:2px solid #d1d5db;position:relative;transition:border-color .15s;}
+				.mptbm_pm_card.is-selected .mptbm_pm_radio{border-color:var(--mptbm-cc-accent);}
+				.mptbm_pm_card.is-selected .mptbm_pm_radio:after{content:"";position:absolute;inset:4px;border-radius:50%;background:var(--mptbm-cc-accent);}
+				@media (max-width:560px){.mptbm_cc_fields{grid-template-columns:1fr;}}
+				</style>
+				<?php
+			}
+
+			/*
+			 * ---------------------------------------------------------------
+			 * Booking submit
+			 * ------------------------------------------------------------ */
+
+			/**
+			 * Handle "Book Now" for the standalone Offline flow.
+			 *
+			 * Filter contract (see MPTBM_Woocommerce::mptbm_add_to_cart): return a plain
+			 * URL to redirect the browser, or HTML containing a <div> to show inline.
+			 * Returning the untouched $response leaves the request to another handler.
+			 *
+			 * @param string $response Response so far ('' when unhandled).
+			 * @return string
+			 */
+			public function process_checkout($response, $posted = array()) {
+				if ($response !== '' || !$this->is_active()) {
+					return $response;
+				}
+
+				if (!is_user_logged_in() && $this->login_required()) {
+					return $this->error_html(esc_html__('Please sign in to complete your booking.', 'ecab-taxi-booking-manager'));
+				}
+
+				$post_id = $this->resolve_vehicle_id(isset($_POST['link_id']) ? $_POST['link_id'] : 0);
+				if (!$post_id) {
+					return $this->error_html(esc_html__('Invalid vehicle selected. Please start your booking again.', 'ecab-taxi-booking-manager'));
+				}
+
+				$quantity = isset($_POST['transport_quantity']) ? max(1, absint($_POST['transport_quantity'])) : 1;
+
+				$name  = isset($_POST['mptbm_billing_name']) ? sanitize_text_field(wp_unslash($_POST['mptbm_billing_name'])) : '';
+				$email = isset($_POST['mptbm_billing_email']) ? sanitize_email(wp_unslash($_POST['mptbm_billing_email'])) : '';
+				$phone = isset($_POST['mptbm_billing_phone']) ? sanitize_text_field(wp_unslash($_POST['mptbm_billing_phone'])) : '';
+				if ((!$name || !$email) && is_user_logged_in()) {
+					$user  = wp_get_current_user();
+					$name  = $name ?: $user->display_name;
+					$email = $email ?: $user->user_email;
+				}
+				if (!$name || !$email || !is_email($email)) {
+					return $this->error_html(esc_html__('Please enter a valid name and email address.', 'ecab-taxi-booking-manager'));
+				}
+
+				// Fare is always recomputed here - the posted price is display-only.
+				$unit_price = $this->get_total_price($post_id);
+				$total      = round((float) $unit_price * $quantity, 2);
+
+				$meta = $this->build_booking_meta($post_id, $quantity, $unit_price, $total, $name, $email, $phone);
+
+				$booking_id = $this->create_booking($name, $meta);
+				if (!$booking_id) {
+					return $this->error_html(esc_html__('Could not create the booking. Please try again.', 'ecab-taxi-booking-manager'));
+				}
+
+				return $this->confirmation_url($booking_id);
+			}
+
+			/**
+			 * Server-side fare for one vehicle incl. extra services.
+			 * Mirrors MPTBM_Woocommerce's cart price calculation.
+			 */
+			private function get_total_price($post_id): float {
+				$distance = isset($_POST['mptbm_distance']) ? absint($_POST['mptbm_distance']) : (isset($_COOKIE['mptbm_distance']) ? absint($_COOKIE['mptbm_distance']) : 1000);
+				$duration = isset($_POST['mptbm_duration']) ? absint($_POST['mptbm_duration']) : (isset($_COOKIE['mptbm_duration']) ? absint($_COOKIE['mptbm_duration']) : 3600);
+				$start    = isset($_POST['mptbm_start_place']) ? sanitize_text_field(wp_unslash($_POST['mptbm_start_place'])) : '';
+				$end      = isset($_POST['mptbm_end_place']) ? sanitize_text_field(wp_unslash($_POST['mptbm_end_place'])) : '';
+				$waiting  = isset($_POST['mptbm_waiting_time']) ? sanitize_text_field(wp_unslash($_POST['mptbm_waiting_time'])) : 0;
+				$two_way  = isset($_POST['mptbm_taxi_return']) ? sanitize_text_field(wp_unslash($_POST['mptbm_taxi_return'])) : 1;
+				$fixed    = isset($_POST['mptbm_fixed_hours']) ? sanitize_text_field(wp_unslash($_POST['mptbm_fixed_hours'])) : 0;
+
+				$price_based = isset($_POST['mptbm_original_price_base']) ? sanitize_text_field(wp_unslash($_POST['mptbm_original_price_base'])) : '';
+				$geo_coords  = null;
+				if (in_array($price_based, array('fixed_zone', 'fixed_zone_dropoff'), true)) {
+					$start_coords = isset($_POST['start_place_coordinates']) ? wp_unslash($_POST['start_place_coordinates']) : '';
+					$end_coords   = isset($_POST['end_place_coordinates']) ? wp_unslash($_POST['end_place_coordinates']) : '';
+					if ($price_based === 'fixed_zone_dropoff' && !empty($start_coords)) {
+						$geo_coords = $this->parse_coords($start_coords);
+					} elseif ($price_based === 'fixed_zone' && !empty($end_coords)) {
+						$geo_coords = $this->parse_coords($end_coords);
+					}
+				}
+
+				$price     = MPTBM_Function::get_price($post_id, $distance, $duration, $start, $end, $waiting, $two_way, $fixed, $geo_coords);
+				$raw_price = (float) MP_Global_Function::price_convert_raw(MP_Global_Function::wc_price($post_id, $price));
+
+				foreach ($this->posted_extra_services($post_id) as $service) {
+					$raw_price += (float) $service['service_price'] * (int) $service['service_quantity'];
+				}
+
+				return $raw_price;
+			}
+
+			/** Normalised extra-service rows from the posted arrays (name/qty/unit price). */
+			private function posted_extra_services($post_id): array {
+				$names = isset($_POST['mptbm_extra_service']) ? array_map('sanitize_text_field', (array) wp_unslash($_POST['mptbm_extra_service'])) : array();
+				$qtys  = isset($_POST['mptbm_extra_service_qty']) ? array_map('absint', (array) wp_unslash($_POST['mptbm_extra_service_qty'])) : array();
+				$names = array_values($names);
+				$qtys  = array_values($qtys);
+
+				$rows = array();
+				for ($i = 0; $i < count($names); $i++) {
+					if (empty($names[$i])) {
+						continue;
+					}
+					$rows[] = array(
+						'service_name'     => $names[$i],
+						'service_quantity' => (isset($qtys[$i]) && $qtys[$i] > 0) ? $qtys[$i] : 1,
+						'service_price'    => (float) MPTBM_Function::get_extra_service_price_by_name($post_id, $names[$i]),
+					);
+				}
+				return $rows;
+			}
+
+			/** Booking meta, matching the schema the WooCommerce flow writes. */
+			private function build_booking_meta($post_id, $quantity, $unit_price, $total, $name, $email, $phone): array {
+				$post_value = function ($key, $default = '') {
+					return isset($_POST[$key]) ? sanitize_text_field(wp_unslash($_POST[$key])) : $default;
+				};
+
+				$meta = array(
+					'mptbm_id'                          => $post_id,
+					// The price model the customer searched with. Stored so a fare can be
+					// recomputed later (admin booking edit) without it - see the
+					// mptbm_original_price_based filter in MPTBM_Function::get_price().
+					'mptbm_original_price_base'         => $post_value('mptbm_original_price_base'),
+					'mptbm_date'                        => $post_value('mptbm_date'),
+					'mptbm_start_place'                 => $post_value('mptbm_start_place'),
+					'mptbm_end_place'                   => $post_value('mptbm_end_place'),
+					'mptbm_extra_stop_place'            => $post_value('mptbm_extra_stop_place'),
+					'mptbm_waiting_time'                => $post_value('mptbm_waiting_time', 0),
+					'mptbm_taxi_return'                 => $post_value('mptbm_taxi_return', 1),
+					'mptbm_fixed_hours'                 => $post_value('mptbm_fixed_hours', 0),
+					'mptbm_distance'                    => isset($_POST['mptbm_distance']) ? absint($_POST['mptbm_distance']) : '',
+					'mptbm_duration'                    => isset($_POST['mptbm_duration']) ? absint($_POST['mptbm_duration']) : '',
+					'mptbm_base_price'                  => $unit_price,
+					'mptbm_threshold_base_price'        => $post_value('mptbm_threshold_base_price', 0),
+					'mptbm_order_status'                => 'pending',
+					'mptbm_user_id'                     => get_current_user_id(),
+					'mptbm_tp'                          => $total,
+					'mptbm_service_info'                => $this->posted_extra_services($post_id),
+					'mptbm_billing_name'                => $name,
+					'mptbm_billing_email'               => $email,
+					'mptbm_billing_phone'               => $phone,
+					'mptbm_payment_method'              => $this->offline_label(),
+					'mptbm_target_pickup_interval_time' => MPTBM_Function::get_general_settings('mptbm_pickup_interval_time', '30'),
+					'mptbm_transport_quantity'          => $quantity,
+				);
+
+				$return_date = $post_value('mptbm_return_date');
+				$return_time = $post_value('mptbm_return_time');
+				if ($return_date) {
+					$meta['mptbm_return_target_date'] = $return_date;
+				}
+				if ($return_time) {
+					$meta['mptbm_return_target_time'] = $return_time;
+				}
+				if (isset($_POST['mptbm_passengers'])) {
+					$meta['mptbm_passengers'] = absint($_POST['mptbm_passengers']);
+				}
+
+				return apply_filters('add_mptbm_booking_data', $meta, $post_id);
+			}
+
+			/**
+			 * Insert the booking post + meta. Replicates MPTBM_Woocommerce::add_cpt_data()
+			 * (unavailable logic-wise here because there is no WooCommerce order): the
+			 * booking is its own order, so mptbm_order_id is its own id and mptbm_pin is
+			 * derived the same way.
+			 *
+			 * Offline bookings are always 'pending' - payment happens off-site, so an admin
+			 * confirms them manually.
+			 */
+			private function create_booking($title, $meta) {
+				$booking_id = wp_insert_post(array(
+					'post_title'  => $title ?: esc_html__('Booking', 'ecab-taxi-booking-manager'),
+					'post_type'   => 'mptbm_booking',
+					'post_status' => 'pending',
+				));
+
+				if (is_wp_error($booking_id) || !$booking_id) {
+					return 0;
+				}
+
+				$meta['mptbm_order_id']     = $booking_id;
+				$meta['mptbm_order_status'] = 'pending';
+				$meta['mptbm_payment_gateway'] = 'offline';
+
+				foreach ($meta as $key => $value) {
+					update_post_meta($booking_id, $key, $value);
+				}
+
+				update_post_meta($booking_id, 'mptbm_pin', $meta['mptbm_user_id'] . $meta['mptbm_order_id'] . $meta['mptbm_id'] . $booking_id);
+
+				do_action('mptbm_custom_booking_created', $booking_id, $meta, 'pending');
+				$this->send_notifications($booking_id, $meta);
+
+				return $booking_id;
+			}
+
+			/**
+			 * Minimal plain-text confirmation to the customer + the shop admin. Without
+			 * this an offline booking would be recorded with nobody told about it. Pro
+			 * replaces this with its templated native booking mail.
+			 */
+			private function send_notifications($booking_id, $meta): void {
+				if (!apply_filters('mptbm_offline_send_notifications', true, $booking_id, $meta)) {
+					return;
+				}
+
+				$site      = wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES);
+				$reference = '#' . $booking_id;
+				$total     = MP_Global_Function::format_price($meta['mptbm_tp']);
+				$lines     = array(
+					sprintf(esc_html__('Booking reference: %s', 'ecab-taxi-booking-manager'), $reference),
+					sprintf(esc_html__('Pickup: %s', 'ecab-taxi-booking-manager'), $meta['mptbm_start_place']),
+					sprintf(esc_html__('Drop-off: %s', 'ecab-taxi-booking-manager'), $meta['mptbm_end_place']),
+					sprintf(esc_html__('Date: %s', 'ecab-taxi-booking-manager'), $meta['mptbm_date']),
+					sprintf(esc_html__('Total: %s', 'ecab-taxi-booking-manager'), wp_strip_all_tags($total)),
+					sprintf(esc_html__('Payment: %s (to be paid offline)', 'ecab-taxi-booking-manager'), $meta['mptbm_payment_method']),
+				);
+				$body = implode("\n", $lines);
+
+				wp_mail(
+					$meta['mptbm_billing_email'],
+					sprintf(esc_html__('[%1$s] Your booking %2$s is received', 'ecab-taxi-booking-manager'), $site, $reference),
+					esc_html__('Thank you for your booking. We have received it and will confirm shortly.', 'ecab-taxi-booking-manager') . "\n\n" . $body
+				);
+
+				wp_mail(
+					get_option('admin_email'),
+					sprintf(esc_html__('[%1$s] New offline booking %2$s', 'ecab-taxi-booking-manager'), $site, $reference),
+					sprintf(esc_html__('A new booking was placed by %1$s (%2$s).', 'ecab-taxi-booking-manager'), $meta['mptbm_billing_name'], $meta['mptbm_billing_email']) . "\n\n" . $body
+				);
+			}
+
+			/*
+			 * ---------------------------------------------------------------
+			 * Confirmation page
+			 * ------------------------------------------------------------ */
+
+			/** Confirmation URL, keyed by booking id + PIN so ids can't simply be guessed. */
+			private function confirmation_url($booking_id): string {
+				$opts    = get_option(self::SETTINGS_OPTION, array());
+				$page_id = (is_array($opts) && !empty($opts['mptbm_confirmation_page_id'])) ? absint($opts['mptbm_confirmation_page_id']) : 0;
+				$base    = ($page_id && get_post_status($page_id) === 'publish') ? get_permalink($page_id) : home_url('/');
+
+				return add_query_arg(array(
+					'mptbm_booking'    => 'pending',
+					'mptbm_booking_id' => $booking_id,
+					'mptbm_pin'        => rawurlencode((string) get_post_meta($booking_id, 'mptbm_pin', true)),
+				), $base);
+			}
+
+			public function register_confirmation_shortcode(): void {
+				if ($this->pro_active()) {
+					return; // Pro registers the same shortcode with its richer template.
+				}
+				add_shortcode(self::CONFIRMATION_SHORTCODE, array($this, 'render_confirmation'));
+			}
+
+			/**
+			 * Auto-create the confirmation page and select it in Payments settings.
+			 * Idempotent and cheap; uses the same option keys as Pro so a later upgrade
+			 * reuses the very same page instead of creating a second one.
+			 */
+			public function ensure_confirmation_page(): void {
+				if ($this->pro_active() || !MPTBM_Function::offline_payment_enabled() || !current_user_can('manage_options')) {
+					return;
+				}
+
+				$opts    = get_option(self::SETTINGS_OPTION, array());
+				$opts    = is_array($opts) ? $opts : array();
+				$page_id = !empty($opts['mptbm_confirmation_page_id']) ? absint($opts['mptbm_confirmation_page_id']) : 0;
+				if ($page_id && get_post_status($page_id) === 'publish') {
+					return;
+				}
+
+				$auto = absint(get_option(self::AUTO_PAGE_OPTION, 0));
+				if ($auto && get_post_status($auto) === 'publish') {
+					$page_id = $auto;
+				} else {
+					$page_id = wp_insert_post(array(
+						'post_title'     => esc_html__('Booking Confirmation', 'ecab-taxi-booking-manager'),
+						'post_name'      => 'booking-confirmation',
+						'post_content'   => '[' . self::CONFIRMATION_SHORTCODE . ']',
+						'post_status'    => 'publish',
+						'post_type'      => 'page',
+						'comment_status' => 'closed',
+					));
+					if (is_wp_error($page_id) || !$page_id) {
+						return;
+					}
+					update_option(self::AUTO_PAGE_OPTION, $page_id);
+				}
+
+				$opts['mptbm_confirmation_page_id'] = $page_id;
+				update_option(self::SETTINGS_OPTION, $opts);
+			}
+
+			/** [mptbm_booking_confirmation] - booking summary after an offline booking. */
+			public function render_confirmation() {
+				$booking_id = isset($_GET['mptbm_booking_id']) ? absint($_GET['mptbm_booking_id']) : 0;
+				$pin        = isset($_GET['mptbm_pin']) ? sanitize_text_field(wp_unslash($_GET['mptbm_pin'])) : '';
+
+				if (!$booking_id || get_post_type($booking_id) !== 'mptbm_booking') {
+					return '<p>' . esc_html__('No booking to show.', 'ecab-taxi-booking-manager') . '</p>';
+				}
+
+				// A booking is readable with its PIN, or by the account that placed it.
+				$stored_pin = (string) get_post_meta($booking_id, 'mptbm_pin', true);
+				$owner_id   = absint(get_post_meta($booking_id, 'mptbm_user_id', true));
+				$is_owner   = $owner_id && get_current_user_id() === $owner_id;
+				if (!hash_equals($stored_pin, $pin) && !$is_owner && !current_user_can('manage_options')) {
+					return '<p>' . esc_html__('This booking could not be verified.', 'ecab-taxi-booking-manager') . '</p>';
+				}
+
+				$get = function ($key) use ($booking_id) {
+					return get_post_meta($booking_id, $key, true);
+				};
+
+				$rows = array(
+					esc_html__('Booking reference', 'ecab-taxi-booking-manager') => '#' . $booking_id,
+					esc_html__('Status', 'ecab-taxi-booking-manager')            => esc_html__('Pending confirmation', 'ecab-taxi-booking-manager'),
+					esc_html__('Name', 'ecab-taxi-booking-manager')              => $get('mptbm_billing_name'),
+					esc_html__('Email', 'ecab-taxi-booking-manager')             => $get('mptbm_billing_email'),
+					esc_html__('Phone', 'ecab-taxi-booking-manager')             => $get('mptbm_billing_phone'),
+					esc_html__('Pickup', 'ecab-taxi-booking-manager')            => $get('mptbm_start_place'),
+					esc_html__('Drop-off', 'ecab-taxi-booking-manager')          => $get('mptbm_end_place'),
+					esc_html__('Date', 'ecab-taxi-booking-manager')              => $get('mptbm_date'),
+					esc_html__('Payment method', 'ecab-taxi-booking-manager')    => $get('mptbm_payment_method'),
+					esc_html__('Total', 'ecab-taxi-booking-manager')             => wp_strip_all_tags(MP_Global_Function::format_price($get('mptbm_tp'))),
+				);
+
+				ob_start();
+				?>
+				<div class="mptbm_booking_confirmation">
+					<div class="mptbm_bc_head">
+						<span class="mptbm_bc_tick" aria-hidden="true">&#10003;</span>
+						<h2><?php esc_html_e('Thank you! Your booking is received.', 'ecab-taxi-booking-manager'); ?></h2>
+						<p><?php esc_html_e('We have emailed you the details. Your booking is pending until we confirm it - payment is taken offline.', 'ecab-taxi-booking-manager'); ?></p>
+					</div>
+					<table class="mptbm_bc_table">
+						<tbody>
+						<?php foreach ($rows as $label => $value) : ?>
+							<?php if ($value === '' || $value === null) { continue; } ?>
+							<tr>
+								<th><?php echo esc_html($label); ?></th>
+								<td><?php echo esc_html($value); ?></td>
+							</tr>
+						<?php endforeach; ?>
+						</tbody>
+					</table>
+				</div>
+				<style>
+				.mptbm_booking_confirmation{max-width:640px;margin:0 auto;padding:26px;border:1px solid #e5e7eb;border-radius:16px;background:#fff;box-shadow:0 6px 24px rgba(16,24,40,.06);}
+				.mptbm_bc_head{text-align:center;margin-bottom:22px;}
+				.mptbm_bc_tick{display:inline-flex;align-items:center;justify-content:center;width:52px;height:52px;border-radius:50%;background:linear-gradient(135deg,#0f766e,#115e59);color:#fff;font-size:24px;margin-bottom:12px;}
+				.mptbm_bc_head h2{margin:0 0 8px;font-size:20px;font-weight:700;color:#1f2937;}
+				.mptbm_bc_head p{margin:0;font-size:14px;color:#6b7280;line-height:1.6;}
+				.mptbm_bc_table{width:100%;border-collapse:collapse;}
+				.mptbm_bc_table th,.mptbm_bc_table td{padding:11px 4px;border-bottom:1px solid #f1f2f4;font-size:14px;text-align:left;vertical-align:top;}
+				.mptbm_bc_table th{color:#6b7280;font-weight:600;width:42%;}
+				.mptbm_bc_table td{color:#1f2937;}
+				</style>
+				<?php
+				return ob_get_clean();
+			}
+
+			/*
+			 * ---------------------------------------------------------------
+			 * Helpers
+			 * ------------------------------------------------------------ */
+
+			/**
+			 * Resolve a posted link_id to the underlying transportation (mptbm_rent) id.
+			 * In standalone mode extra_service.php posts the vehicle id directly; a stale
+			 * WooCommerce product id is mapped back via its link_mptbm_id meta.
+			 */
+			private function resolve_vehicle_id($id): int {
+				$id = absint($id);
+				if (!$id) {
+					return 0;
+				}
+				$cpt = MPTBM_Function::get_cpt();
+				if (get_post_type($id) === $cpt) {
+					return $id;
+				}
+				$linked = absint(get_post_meta($id, 'link_mptbm_id', true));
+				return ($linked && get_post_type($linked) === $cpt) ? $linked : 0;
+			}
+
+			/** Parse a coordinate string/JSON the same way the WooCommerce flow does. */
+			private function parse_coords($raw) {
+				if (is_array($raw)) {
+					return $raw;
+				}
+				$decoded = json_decode((string) $raw, true);
+				return is_array($decoded) ? $decoded : null;
+			}
+
+			/** Error markup - the booking JS shows any response containing a <div> inline. */
+			private function error_html($message): string {
+				return '<div class="mptbm_booking_error" style="padding:14px 16px;border:1px solid #f5c2c7;background:#f8d7da;color:#842029;border-radius:8px;">' . esc_html($message) . '</div>';
+			}
+		}
+
+		new MPTBM_Offline_Checkout();
+	}

--- a/inc/MPTBM_Booking_Mode.php
+++ b/inc/MPTBM_Booking_Mode.php
@@ -36,9 +36,22 @@
 				return class_exists( 'MP_Global_Function' ) && MP_Global_Function::check_woocommerce() === 1;
 			}
 
-			/** Only the Pro plugin can actually run the custom/standalone checkout. */
+			/** The Pro plugin provides the full custom/standalone checkout (PayPal, Stripe, portal). */
 			public static function has_pro() {
 				return class_exists( 'MPTBM_Plugin_Pro' );
+			}
+
+			/**
+			 * Whether the custom/standalone flow can actually process a booking.
+			 *
+			 * Two independent sources qualify:
+			 *  - The Pro plugin's MPTBM_Native_Checkout (PayPal / Stripe / Offline).
+			 *  - The FREE built-in Offline method, which needs no online processor and is
+			 *    handled by MPTBM_Offline_Checkout (see MPTBM_Function::offline_payment_enabled()).
+			 */
+			public static function has_custom() {
+				return self::has_pro()
+					|| ( class_exists( 'MPTBM_Function' ) && MPTBM_Function::offline_payment_enabled() );
 			}
 
 			/**
@@ -48,15 +61,15 @@
 			 * @return string 'both' | 'woocommerce_only' | 'custom_only' | 'none'
 			 */
 			public static function availability() {
-				$woo = self::has_woo();
-				$pro = self::has_pro();
-				if ( $woo && $pro ) {
+				$woo    = self::has_woo();
+				$custom = self::has_custom();
+				if ( $woo && $custom ) {
 					return 'both';
 				}
 				if ( $woo ) {
 					return 'woocommerce_only';
 				}
-				if ( $pro ) {
+				if ( $custom ) {
 					return 'custom_only';
 				}
 				return 'none';
@@ -100,9 +113,9 @@
 			public static function get_mode() {
 				switch ( self::availability() ) {
 					case 'woocommerce_only':
-						return self::WOOCOMMERCE;
+						return self::remember( self::WOOCOMMERCE );
 					case 'custom_only':
-						return self::CUSTOM;
+						return self::remember( self::CUSTOM );
 					case 'none':
 						return '';
 					case 'both':
@@ -110,6 +123,27 @@
 						// Safe default (matches the old checkbox's default) until an explicit choice is saved.
 						return self::get_stored_mode() ?: self::WOOCOMMERCE;
 				}
+			}
+
+			/**
+			 * Record a mode that was auto-resolved because it was the ONLY flow available.
+			 *
+			 * Without this, a site running one flow has nothing stored, so the day the other
+			 * flow becomes available two things go wrong: the admin is nagged to choose a
+			 * mode they effectively already had, and - worse - the 'both' fallback silently
+			 * hands bookings to WooCommerce. A site taking Offline bookings would have its
+			 * checkout hijacked simply by activating WooCommerce.
+			 *
+			 * Only ever fills a blank: an explicit choice (or an earlier auto-resolution) is
+			 * never overwritten, so deactivating a flow temporarily doesn't erase intent.
+			 *
+			 * @return string The mode passed in, so callers can return it directly.
+			 */
+			private static function remember( $mode ) {
+				if ( '' === self::get_stored_mode() ) {
+					self::set_mode( $mode );
+				}
+				return $mode;
 			}
 
 			public static function is_woocommerce() {

--- a/inc/MPTBM_Dependencies.php
+++ b/inc/MPTBM_Dependencies.php
@@ -55,6 +55,21 @@ if (!class_exists('MPTBM_Dependencies')) {
 				new MPTBM_REST_API();
 			}
 		}
+        /**
+         * Cache-busting version for a bundled asset: the file's own mtime, so the
+         * browser caches it until it actually changes. Replaces time(), which gave a
+         * unique ?ver= every request — the asset was never cached and got re-downloaded
+         * on every load, showing as a flash of unstyled content until it arrived.
+         *
+         * @param string $rel Path relative to the plugin root, e.g. 'assets/admin/x.css'.
+         * @return string|int
+         */
+        private function asset_ver($rel)
+        {
+            $path = MPTBM_PLUGIN_DIR . '/' . ltrim($rel, '/');
+            return file_exists($path) ? filemtime($path) : ( defined('MPTBM_PLUGIN_VERSION') ? MPTBM_PLUGIN_VERSION : '1.0' );
+        }
+
         public function global_enqueue()
         {
             $api_key = MP_Global_Function::get_settings('mptbm_map_api_settings', 'gmap_api_key');
@@ -66,12 +81,12 @@ if (!class_exists('MPTBM_Dependencies')) {
             // Check map type FIRST, then decide what to load
             if ($map_type === 'openstreetmap') {
                 // OpenStreetMap is selected - load only the map JS without Google Maps API
-                wp_enqueue_script('mptbm_admin_map', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_map.js', array('jquery'), time(), true);
+                wp_enqueue_script('mptbm_admin_map', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_map.js', array('jquery'), $this->asset_ver('assets/admin/mptbm_map.js'), true);
             } elseif ($map_type === 'enable' && $api_key) {
                 // Google Maps is selected and API key exists
 //                wp_enqueue_script('mptbm_map_api', 'https://maps.googleapis.com/maps/api/js?libraries=places,drawing&language=en&v=weekly&key=' . $api_key, array(), null, true);
                 wp_enqueue_script('mptbm_map_api', 'https://maps.googleapis.com/maps/api/js?libraries=places,drawing,geometry&language=en&v=3.64&key=' . $api_key, array(), null, true);
-                wp_enqueue_script('mptbm_admin_map', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_map.js', array('mptbm_map_api'), time(), true);
+                wp_enqueue_script('mptbm_admin_map', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_map.js', array('mptbm_map_api'), $this->asset_ver('assets/admin/mptbm_map.js'), true);
             } elseif ($map_type === 'enable' && !$api_key) {
                 // Google Maps is selected but no API key
                 add_action('admin_notices', [$this, 'map_api_not_active']);
@@ -79,21 +94,21 @@ if (!class_exists('MPTBM_Dependencies')) {
             // If map_type is 'disable', don't load anything
             
             do_action('add_mptbm_common_script');
-            wp_enqueue_style('mage-icons', MPTBM_PLUGIN_URL . '/assets/mage-icon/css/mage-icon.css', array(), time());
+            wp_enqueue_style('mage-icons', MPTBM_PLUGIN_URL . '/assets/mage-icon/css/mage-icon.css', array(), $this->asset_ver('assets/mage-icon/css/mage-icon.css'));
         }
 
         public function admin_enqueue()
         {
             $this->global_enqueue();
             // custom
-            wp_enqueue_style('mptbm_admin', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_admin.css', array(), time());
-            wp_enqueue_style('admin_style', MPTBM_PLUGIN_URL . '/assets/admin/admin_style.css', array(), time());
-            wp_enqueue_style('mptbm_right_side_style', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_right_side_style.css', array(), time());
-            wp_enqueue_style('mptbm_taxi_add_edit', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_taxi_add_edit.css', array(), time());
-            wp_enqueue_style('mptbm_ex_service', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_ex_service.css', array(), time());
-            wp_enqueue_style('mptbm_date_and_advanced', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_date_and_advanced.css', array(), time());
+            wp_enqueue_style('mptbm_admin', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_admin.css', array(), $this->asset_ver('assets/admin/mptbm_admin.css'));
+            wp_enqueue_style('admin_style', MPTBM_PLUGIN_URL . '/assets/admin/admin_style.css', array(), $this->asset_ver('assets/admin/admin_style.css'));
+            wp_enqueue_style('mptbm_right_side_style', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_right_side_style.css', array(), $this->asset_ver('assets/admin/mptbm_right_side_style.css'));
+            wp_enqueue_style('mptbm_taxi_add_edit', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_taxi_add_edit.css', array(), $this->asset_ver('assets/admin/mptbm_taxi_add_edit.css'));
+            wp_enqueue_style('mptbm_ex_service', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_ex_service.css', array(), $this->asset_ver('assets/admin/mptbm_ex_service.css'));
+            wp_enqueue_style('mptbm_date_and_advanced', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_date_and_advanced.css', array(), $this->asset_ver('assets/admin/mptbm_date_and_advanced.css'));
             // Ensure jQuery UI Sortable is loaded before the add/edit script so drag handles work
-            wp_enqueue_script('mptbm_taxi_add_edit', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_taxi_add_edit.js', array('jquery', 'jquery-ui-sortable'), time(), true);
+            wp_enqueue_script('mptbm_taxi_add_edit', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_taxi_add_edit.js', array('jquery', 'jquery-ui-sortable'), $this->asset_ver('assets/admin/mptbm_taxi_add_edit.js'), true);
             wp_localize_script('mptbm_taxi_add_edit', 'mptbm_editor_l10n', array(
                 'ajax_url'   => admin_url('admin-ajax.php'),
                 'action'     => 'mptbm_ajax_save_rent',
@@ -105,27 +120,27 @@ if (!class_exists('MPTBM_Dependencies')) {
                     'network_error' => __('Could not reach the server. Please check your connection and try again.', 'ecab-taxi-booking-manager'),
                 ),
             ));
-            wp_enqueue_script('mptbm_admin', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_admin.js', array('jquery'), time(), true);
-            wp_enqueue_script('mptbm_tooltip', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_tooltip.js', array('jquery'), time(), true);
-            wp_enqueue_script('mptbm_transportation_lists', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_transportation_lists.js', array('jquery'), time(), true);
-            wp_enqueue_script('mptbm_right_side_js', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_right_side_js.js', array('jquery'), time(), true);
-            wp_enqueue_style('mptbm_transportation_lists', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_transportation_lists.css', array(), time());
+            wp_enqueue_script('mptbm_admin', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_admin.js', array('jquery'), $this->asset_ver('assets/admin/mptbm_admin.js'), true);
+            wp_enqueue_script('mptbm_tooltip', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_tooltip.js', array('jquery'), $this->asset_ver('assets/admin/mptbm_tooltip.js'), true);
+            wp_enqueue_script('mptbm_transportation_lists', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_transportation_lists.js', array('jquery'), $this->asset_ver('assets/admin/mptbm_transportation_lists.js'), true);
+            wp_enqueue_script('mptbm_right_side_js', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_right_side_js.js', array('jquery'), $this->asset_ver('assets/admin/mptbm_right_side_js.js'), true);
+            wp_enqueue_style('mptbm_transportation_lists', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_transportation_lists.css', array(), $this->asset_ver('assets/admin/mptbm_transportation_lists.css'));
 
             $editor_type = isset( $_GET['editor'] ) ? sanitize_text_field( wp_unslash( $_GET['editor'] ) ) : 'new';
             if ( $editor_type !== 'old') {
                 if ( class_exists('Distance_Tier_Pricing_Addon') || function_exists('distance_tier_pricing_addon_init')) {
-                    wp_enqueue_style('admin-distance-tier-pricing', MPTBM_PLUGIN_URL . '/assets/admin/distance_tier_pricing/css/admin-distance-tier-pricing.css', array(), time());
-                    wp_enqueue_script('admin-distance-tier-pricing', MPTBM_PLUGIN_URL . '/assets/admin/distance_tier_pricing/js/admin-distance-tier-pricing.js', array('jquery'), time(), true);
+                    wp_enqueue_style('admin-distance-tier-pricing', MPTBM_PLUGIN_URL . '/assets/admin/distance_tier_pricing/css/admin-distance-tier-pricing.css', array(), $this->asset_ver('assets/admin/distance_tier_pricing/css/admin-distance-tier-pricing.css'));
+                    wp_enqueue_script('admin-distance-tier-pricing', MPTBM_PLUGIN_URL . '/assets/admin/distance_tier_pricing/js/admin-distance-tier-pricing.js', array('jquery'), $this->asset_ver('assets/admin/distance_tier_pricing/js/admin-distance-tier-pricing.js'), true);
                 }
 
                 if (class_exists('Taxi_Peak_Hour_Pricing_Addon') || function_exists('taxi_peak_hour_pricing_addon_init')) {
-                    wp_enqueue_style('admin-peak-hour-pricing', MPTBM_PLUGIN_URL . '/assets/admin/peak_hour_pricing_addon/css/admin-peak-hour-pricing.css', array(), time());
-                    wp_enqueue_script('admin-peak-hour-pricing', MPTBM_PLUGIN_URL . '/assets/admin/peak_hour_pricing_addon/js/admin-peak-hour-pricing.js', array('jquery'), time(), true);
+                    wp_enqueue_style('admin-peak-hour-pricing', MPTBM_PLUGIN_URL . '/assets/admin/peak_hour_pricing_addon/css/admin-peak-hour-pricing.css', array(), $this->asset_ver('assets/admin/peak_hour_pricing_addon/css/admin-peak-hour-pricing.css'));
+                    wp_enqueue_script('admin-peak-hour-pricing', MPTBM_PLUGIN_URL . '/assets/admin/peak_hour_pricing_addon/js/admin-peak-hour-pricing.js', array('jquery'), $this->asset_ver('assets/admin/peak_hour_pricing_addon/js/admin-peak-hour-pricing.js'), true);
                 }
             }
 
             // No transport templates
-            wp_enqueue_script('mptbm-no-transport-templates', MPTBM_PLUGIN_URL . '/assets/admin/js/no-transport-templates.js', array('jquery'), time(), true);
+            wp_enqueue_script('mptbm-no-transport-templates', MPTBM_PLUGIN_URL . '/assets/admin/js/no-transport-templates.js', array('jquery'), $this->asset_ver('assets/admin/js/no-transport-templates.js'), true);
             
             // Enqueue Leaflet.draw for OpenStreetMap polygon drawing on operation areas page AND settings page
             $screen = get_current_screen();
@@ -150,7 +165,7 @@ if (!class_exists('MPTBM_Dependencies')) {
 
                     // Re-enqueue mptbm_admin_map with Leaflet dependencies
                     wp_deregister_script('mptbm_admin_map');
-                    wp_enqueue_script('mptbm_admin_map', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_map.js', array('jquery', 'leaflet', 'leaflet-draw'), time(), true);
+                    wp_enqueue_script('mptbm_admin_map', MPTBM_PLUGIN_URL . '/assets/admin/mptbm_map.js', array('jquery', 'leaflet', 'leaflet-draw'), $this->asset_ver('assets/admin/mptbm_map.js'), true);
                 }
             }
 
@@ -168,10 +183,10 @@ if (!class_exists('MPTBM_Dependencies')) {
             $this->global_enqueue();
             wp_enqueue_script('wc-checkout');
             //
-            wp_enqueue_style('mptbm_style', MPTBM_PLUGIN_URL . '/assets/frontend/mptbm_style.css', array(), time());
-            wp_enqueue_script('mptbm_script', MPTBM_PLUGIN_URL . '/assets/frontend/mptbm_script.js', array('jquery'), time(), true);
-            wp_enqueue_script('mptbm_registration', MPTBM_PLUGIN_URL . '/assets/frontend/mptbm_registration.js', array('jquery'), time(), true);
-            wp_enqueue_style('mptbm_registration', MPTBM_PLUGIN_URL . '/assets/frontend/mptbm_registration.css', array(), time());
+            wp_enqueue_style('mptbm_style', MPTBM_PLUGIN_URL . '/assets/frontend/mptbm_style.css', array(), $this->asset_ver('assets/frontend/mptbm_style.css'));
+            wp_enqueue_script('mptbm_script', MPTBM_PLUGIN_URL . '/assets/frontend/mptbm_script.js', array('jquery'), $this->asset_ver('assets/frontend/mptbm_script.js'), true);
+            wp_enqueue_script('mptbm_registration', MPTBM_PLUGIN_URL . '/assets/frontend/mptbm_registration.js', array('jquery'), $this->asset_ver('assets/frontend/mptbm_registration.js'), true);
+            wp_enqueue_style('mptbm_registration', MPTBM_PLUGIN_URL . '/assets/frontend/mptbm_registration.css', array(), $this->asset_ver('assets/frontend/mptbm_registration.css'));
 			
 			// Localize script for AJAX
 			wp_localize_script('mptbm_registration', 'mptbm_ajax', array(
@@ -183,7 +198,7 @@ if (!class_exists('MPTBM_Dependencies')) {
             wp_enqueue_style('font-awesome', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css', array(), '5.15.4');
             
             // No transport templates styles
-            wp_enqueue_style('mptbm-no-transport-templates', MPTBM_PLUGIN_URL . '/assets/frontend/css/no-transport-templates.css', array(), time());
+            wp_enqueue_style('mptbm-no-transport-templates', MPTBM_PLUGIN_URL . '/assets/frontend/css/no-transport-templates.css', array(), $this->asset_ver('assets/frontend/css/no-transport-templates.css'));
             
             // Enqueue selectWoo (searchable dropdown) if WooCommerce is active
             if (function_exists('WC')) {

--- a/inc/MPTBM_Function.php
+++ b/inc/MPTBM_Function.php
@@ -152,14 +152,28 @@ if (!class_exists('MPTBM_Function')) {
 		}
 		/**
 		 * Whether a booking can actually be completed end-to-end.
-		 * Free plugin needs WooCommerce for cart/checkout; without it, only the
-		 * Pro plugin's custom (standalone) checkout can complete a booking. If
-		 * neither is available there is no way to take payment, so booking must
-		 * be blocked rather than left to fail silently at the final step.
+		 * Three routes qualify: the WooCommerce cart/checkout, the Pro plugin's custom
+		 * (standalone) checkout, or the free built-in Offline method handled by
+		 * MPTBM_Offline_Checkout. If none is available there is no way to take payment,
+		 * so booking must be blocked rather than left to fail silently at the final step.
 		 */
 		public static function is_booking_available(): bool
 		{
-			return self::is_wc_active() || class_exists('MPTBM_Plugin_Pro');
+			return self::is_wc_active() || class_exists('MPTBM_Plugin_Pro') || self::offline_payment_enabled();
+		}
+		/**
+		 * Whether the built-in Offline payment method is enabled on the Payments tab.
+		 *
+		 * Offline is the one custom payment method that is part of the FREE plugin: it
+		 * needs no online processor, so it can be configured and enabled without Pro
+		 * (PayPal & Stripe configuration stays Pro-only). Stored as
+		 * mptbm_payment_settings[mptbm_offline_enable].
+		 *
+		 * Single source of truth - callers must not read the option key directly.
+		 */
+		public static function offline_payment_enabled(): bool
+		{
+			return MP_Global_Function::get_settings('mptbm_payment_settings', 'mptbm_offline_enable', 'off') === 'on';
 		}
 		public static function get_name()
 		{
@@ -424,7 +438,20 @@ if (!class_exists('MPTBM_Function')) {
 
 			// Get price basis information
 			$price_based = MP_Global_Function::get_post_info($post_id, 'mptbm_price_based');
-			$original_price_based = get_transient('original_price_based');
+			/**
+			 * The price model the customer originally searched with. It normally comes
+			 * from a transient the search step sets (MPTBM_Transport_Search), which means
+			 * anything recomputing a fare OUTSIDE that flow - e.g. an admin re-pricing an
+			 * existing booking - would match no branch below and silently get 0.
+			 *
+			 * The filter lets such callers supply the booking's own stored base for the
+			 * duration of one calculation instead of writing to the shared transient,
+			 * which is global and would corrupt a live customer's in-progress search.
+			 *
+			 * @param string $original_price_based Value from the transient.
+			 * @param int    $post_id              Transportation post being priced.
+			 */
+			$original_price_based = apply_filters('mptbm_original_price_based', get_transient('original_price_based'), $post_id);
 
 			// If original price basis is fixed_hourly but current price basis is distance, return false
 			if ($original_price_based === 'fixed_hourly' && $price_based === 'distance') {
@@ -888,21 +915,47 @@ if (!class_exists('MPTBM_Function')) {
 
 		}
 
-		public static function get_extra_service_price_by_name($post_id, $service_name)
+		/**
+		 * Every extra service a transportation offers, as name => price rows.
+		 *
+		 * Resolves the same way the booking form does: services can live on the vehicle
+		 * itself or on a shared service post referenced by mptbm_extra_services_id, and
+		 * an empty array is returned when the vehicle has them switched off.
+		 *
+		 * @return array<int,array{service_name:string,service_price:float}>
+		 */
+		public static function get_available_extra_services($post_id): array
 		{
 			$display_extra_services = MP_Global_Function::get_post_info($post_id, 'display_mptbm_extra_services', 'on');
+			if ($display_extra_services != 'on') {
+				return [];
+			}
 			$service_id = MP_Global_Function::get_post_info($post_id, 'mptbm_extra_services_id', $post_id);
 			$extra_services = MP_Global_Function::get_post_info($service_id, 'mptbm_extra_service_infos', []);
-			$price = 0;
-			if ($display_extra_services == 'on' && is_array($extra_services) && sizeof($extra_services) > 0) {
-				foreach ($extra_services as $service) {
-					$ex_service_name = array_key_exists('service_name', $service) ? $service['service_name'] : '';
-					if ($ex_service_name == $service_name) {
-						return array_key_exists('service_price', $service) ? $service['service_price'] : 0;
-					}
+			if (!is_array($extra_services)) {
+				return [];
+			}
+			$services = [];
+			foreach ($extra_services as $service) {
+				$name = array_key_exists('service_name', $service) ? $service['service_name'] : '';
+				if ($name === '') {
+					continue;
+				}
+				$services[] = [
+					'service_name'  => $name,
+					'service_price' => (float) (array_key_exists('service_price', $service) ? $service['service_price'] : 0),
+				];
+			}
+			return $services;
+		}
+		public static function get_extra_service_price_by_name($post_id, $service_name)
+		{
+			foreach (self::get_available_extra_services($post_id) as $service) {
+				if ($service['service_name'] == $service_name) {
+					return $service['service_price'];
 				}
 			}
-			return $price;
+			return 0;
 		}
 		/**
 		 * Check if coordinates fall within a fixed_zone end location (operation area polygon or location term radius)

--- a/inc/MPTBM_Payment_Status_Checker.php
+++ b/inc/MPTBM_Payment_Status_Checker.php
@@ -33,13 +33,20 @@
 
 			/**
 			 * Option (shared with MPTBM_Payment_Settings::OPTION) that stores the
-			 * PayPal/Stripe/Offline "Custom Payment" toggles. Their enable UI only
-			 * renders when the Pro plugin is active (see
-			 * Admin/settings/MPTBM_Payment_Settings.php:466-584), so today this
-			 * option - not a Pro-side API - is the actual source of truth for
-			 * "Pro custom payment methods enabled". Read directly rather than via
+			 * PayPal/Stripe/Offline "Custom Payment" toggles, which are what the
+			 * standalone (non-WooCommerce) checkout consumes - so today this option,
+			 * not a Pro-side API, is the actual source of truth for "custom payment
+			 * methods enabled". Read directly rather than via
 			 * MPTBM_Payment_Settings::OPTION so this class doesn't depend on that
 			 * file having loaded first.
+			 *
+			 * Note: PayPal/Stripe configuration is Pro-only, while Offline is
+			 * configurable in the free plugin (see
+			 * MPTBM_Function::offline_payment_enabled()). The counts below are still
+			 * gated on the Pro plugin because only Pro ships the standalone checkout
+			 * that can actually turn an enabled toggle into a completed booking - an
+			 * Offline toggle with nothing to consume it must not silence the
+			 * "no payment method" notice.
 			 */
 			const CUSTOM_PAYMENT_OPTION = 'mptbm_payment_settings';
 
@@ -109,16 +116,25 @@
 			}
 
 			/**
-			 * Number of currently enabled Pro plugin custom payment methods.
-			 * Always 0 when the Pro plugin is not installed/active, since the
-			 * toggles in CUSTOM_PAYMENT_OPTION can only be switched on through
-			 * UI that itself requires the Pro plugin.
+			 * Number of currently enabled custom (non-WooCommerce) payment methods that
+			 * can really complete a booking right now.
+			 *
+			 * Offline counts in the free plugin - MPTBM_Offline_Checkout handles it without
+			 * WooCommerce or Pro. PayPal/Stripe only count when Pro is active, since their
+			 * gateways (and the hosted-checkout return handling) ship with Pro; counting a
+			 * toggle nothing can consume would wrongly silence the payment-setup notice.
+			 *
+			 * Name kept for backward compatibility with existing callers/integrations.
 			 */
 			public static function get_enabled_pro_payment_method_count(): int {
 				$count = 0;
 
+				if (class_exists('MPTBM_Function') && MPTBM_Function::offline_payment_enabled()) {
+					$count++;
+				}
+
 				if (class_exists('MPTBM_Plugin_Pro')) {
-					$count += self::count_enabled_custom_payment_toggles();
+					$count += self::count_enabled_custom_payment_toggles(array('mptbm_paypal_enable', 'mptbm_stripe_enable'));
 				}
 
 				$filtered = apply_filters(self::PRO_PAYMENT_METHODS_FILTER, 0);
@@ -128,17 +144,20 @@
 			}
 
 			/**
-			 * How many of the paypal/stripe/offline toggles in CUSTOM_PAYMENT_OPTION
-			 * are currently set to 'on'.
+			 * How many of the given enable-toggles in CUSTOM_PAYMENT_OPTION are set to 'on'.
+			 *
+			 * @param array $keys Subset of CUSTOM_PAYMENT_ENABLE_KEYS to count; all of them when empty.
 			 */
-			private static function count_enabled_custom_payment_toggles(): int {
+			private static function count_enabled_custom_payment_toggles(array $keys = array()): int {
 				$options = get_option(self::CUSTOM_PAYMENT_OPTION, array());
 				if (!is_array($options)) {
 					return 0;
 				}
 
+				$keys = $keys ?: self::CUSTOM_PAYMENT_ENABLE_KEYS;
+
 				$count = 0;
-				foreach (self::CUSTOM_PAYMENT_ENABLE_KEYS as $key) {
+				foreach ($keys as $key) {
 					if (isset($options[$key]) && $options[$key] === 'on') {
 						$count++;
 					}


### PR DESCRIPTION
- Offline Payment is now a FREE method (configurable + enablable) with a slim standalone checkout (Frontend/MPTBM_Offline_Checkout.php) that records mptbm_booking posts + a confirmation page; stands down when Pro is active.
- MPTBM_Function: offline_payment_enabled(), get_available_extra_services(); is_booking_available() and Booking Mode now recognise Offline, and an auto-resolved mode is persisted so activating WooCommerce can't hijack an Offline-only site.
- "Require Customer Login" defaults to No (guest checkout).
- Payment-setup notice fires only on a real blocker; new dismissible Pro features upsell notice (Admin/MPTBM_Pro_Features_Notice.php).
- Payments tab: the Booking Mode cards are the single switch (redundant sub-tab bar removed).
- Cacheable asset versioning (filemtime instead of time()) to stop the admin flash-of-unstyled-content on reload.