### PR TITLE
Fix custom payment options when WooCommerce is inactive

### DIFF
--- a/Admin/settings/MPTBM_Payment_Settings.php
+++ b/Admin/settings/MPTBM_Payment_Settings.php
@@ -1027,7 +1027,13 @@
 					// The mode actually in effect, resolved server-side. Used when the Booking
 					// Mode cards aren't rendered (only one flow is available, so there is
 					// nothing to choose) - the correct section must still be the visible one.
+					// When neither flow is ready, get_mode() is intentionally empty; show the
+					// Custom section if WooCommerce is unavailable so the admin can enable
+					// Offline Payment instead of hiding the only control that can resolve it.
 					var resolvedMode = <?php echo wp_json_encode( class_exists( 'MPTBM_Booking_Mode' ) ? MPTBM_Booking_Mode::get_mode() : 'woocommerce' ); ?>;
+					if (resolvedMode !== 'woocommerce' && resolvedMode !== 'custom') {
+						resolvedMode = wcActive ? 'woocommerce' : 'custom';
+					}
 
 					var $paymentSubmit = $('div.tabsItem[data-tabs="#<?php echo esc_js( self::OPTION ); ?>"] .submit');
 


### PR DESCRIPTION
## Summary
- show the Custom Payment settings when WooCommerce is unavailable and no booking flow is configured yet
- keep PayPal/Stripe PRO cards, Offline Payment configuration, confirmation page, and login setting visible during initial setup
- match the Rental plugin fallback behavior for the unresolved mode state

## Root cause
`MPTBM_Booking_Mode::get_mode()` intentionally returns an empty value when neither WooCommerce nor a custom gateway is available. The admin visibility script treated that value as WooCommerce mode, then hid all custom-payment rows even though WooCommerce was inactive.

## Testing
- PHP syntax check passed
- `git diff --check` passed
- verified unresolved mode (`availability: none`) resolves to the Custom section for admin display
- verified Custom Payment gateway markup and Offline Configure control are rendered without WooCommerce