### PR TITLE
Fix checkout fields saved with an empty type breaking checkout

### DIFF
--- a/Frontend/MPTBM_Wc_Checkout_Fields_Helper.php
+++ b/Frontend/MPTBM_Wc_Checkout_Fields_Helper.php
@@ -777,12 +777,23 @@
 										
 										// Preserve important default values if custom field has empty values
 										foreach (['type', 'autocomplete'] as $important_key) {
-											if (isset($section_fields[$key][$important_key]) && 
+											if (isset($section_fields[$key][$important_key]) &&
 												(!isset($field[$important_key]) || $field[$important_key] === '')) {
 												$merged_field[$important_key] = $section_fields[$key][$important_key];
 											}
 										}
-										
+
+										// woocommerce_form_field() renders nothing at all for an empty/unknown
+										// type, so an empty saved type silently drops the field from the form
+										// while WC_Checkout still validates it as required - an unfixable
+										// checkout for the customer. The defaults above cannot always repair
+										// this: core fields such as billing_address_1/billing_address_2 have no
+										// explicit 'type' of their own and rely on WooCommerce's 'text' default,
+										// so there is nothing to restore from. Fall back to 'text'.
+										if (empty($merged_field['type'])) {
+											$merged_field['type'] = 'text';
+										}
+
 										// Handle required field properly - use custom setting when available
 										if (isset($field['required'])) {
 											// Custom setting exists, use it (could be '1', '', or '0')
@@ -806,6 +817,10 @@
 										// Handle required field for new custom fields
 										if (isset($field['required'])) {
 											$field['required'] = ($field['required'] === '1') ? true : false;
+										}
+										// See above - an empty type would render nothing.
+										if (empty($field['type'])) {
+											$field['type'] = 'text';
 										}
 										$section_fields[$key] = $field;
 									}

--- a/assets/checkout/js/mptbm-pro-checkout.js
+++ b/assets/checkout/js/mptbm-pro-checkout.js
@@ -289,10 +289,15 @@
 					$('.mpStyles .checkout input[name="new_name"]').val(field.name);
 					$('.mpStyles .checkout input[name="name"]').val(field.name);
 					$('.mpStyles .checkout input[name="name"]').prop('disabled', true);
-					var option = new Option(field.attributes.type, field.attributes.type,'1','1');
+					// Core WooCommerce fields (billing_address_1, billing_address_2, ...) carry
+					// no explicit type and rely on WooCommerce's own 'text' default. Posting the
+					// resulting undefined as new_type saved the field with an empty type, which
+					// WooCommerce renders as nothing while still validating it as required.
+					var field_type = field.attributes.type ? field.attributes.type : 'text';
+					var option = new Option(field_type, field_type,'1','1');
 					$('.mpStyles .checkout select#type').append(option);
 					$('.mpStyles .checkout select#type').prop('disabled', true);
-					$('.mpStyles .checkout input[name="new_type"]').val(field.attributes.type);
+					$('.mpStyles .checkout input[name="new_type"]').val(field_type);
 					$('.mpStyles .checkout input[name="label"]').val(field.attributes.label);
 					$('.mpStyles .checkout input[name="priority"]').val(field.attributes.priority);
 					$('.mpStyles .checkout input[name="class"]').val(field.attributes.class);


### PR DESCRIPTION
woocommerce_form_field() has no default case, so a field stored with type '' renders nothing at all while WC_Checkout still validates it as required. The customer gets "... is a required field" for an input that is not on the page, with no way to complete the order.

The edit modal caused it: core fields such as billing_address_1 and billing_address_2 carry no explicit type of their own and rely on WooCommerce's 'text' default, so reading field.attributes.type gave undefined and posted an empty new_type. Default to 'text' in the modal, and guard on render as well so fields already saved with an empty type are repaired rather than needing a manual re-save.